### PR TITLE
コマンドラインの表示を見やすく改良。また、ksort()にて表示する視聴chを昇順に変更。

### DIFF
--- a/src/quiz.php
+++ b/src/quiz.php
@@ -42,7 +42,7 @@ function display($total_view_time, $channel_time_pairs): void
 {
   // 合計視聴時間を60で割って、小数点第一位までをhour表示する
   $total_view_time_hour = $total_view_time / 60;
-  echo round($total_view_time_hour, 1) . PHP_EOL;
+  echo "合計視聴時間:" . round($total_view_time_hour, 1) . PHP_EOL;
   // 各チャンネルごとに視聴時間を表示させる。
   $result = [];
   $count = [];
@@ -56,13 +56,16 @@ function display($total_view_time, $channel_time_pairs): void
       $count[$number] = 1;
     }
   }
+  ksort($result);
   foreach ($result as $key => $value) {
-    echo $key . " " . $value . " " . $count[$key] . PHP_EOL;
+    echo $key . "ch " . $value . "分 " . $count[$key] . "回視聴" . PHP_EOL;
   }
 }
 
 // メインルーチン
 // 入力データを変数へ格納する
+echo "視聴チャンネル（1~12）およびそのチャンネルの視聴時間(分)を半角スペースで区切って入力してください。" . PHP_EOL;
+echo "入力例 1 40 2 40 4 40 1 30" . PHP_EOL;
 $inputs = trim(fgets(STDIN));
 $channel_time_pairs = channel_time_to_pairs($inputs);
 $total_view_time = calculate_total_view_time($channel_time_pairs);


### PR DESCRIPTION
■作成したプログラム
1~12チャンネルまで設定のあるテレビの、各チャンネルの視聴時間を記録するプログラムを作成しました。

■使用方法
コマンドライン上にて、1 20 3 40 1 60 のように
視聴チャンネル番号(半角スペース)視聴時間
と入力することで、

合計視聴時間（hour）※小数点第一位まで表示
各視聴チャンネル番号(半角スペース)視聴時間(半角スペース)視聴回数
例)
1 20 3 40 1 60　※入力値
合計視聴時間:2.0
1ch 20分 2回視聴
3ch 40分 1回視聴

が表示されます。

記述したコードの処理詳細としては、下記となります。

■標準入力にて入力した値を$inputsに格納

■$inputsを視聴チャンネル、視聴時間のペアに変換
・$inputsをchannel_time_to_pairs()により、$inputsの値をexplode()、array_chunk()を使用することで、半角スペースごとに2つのペア（視聴チャンネル、視聴時間）の配列に変換し、$channel_time_pairsに格納、returnさせる。

■合計視聴時間を算出
・calculate_total_view_time()を使用して、$channel_time_pairsに格納されている視聴時間を合計。$total_view_timeとしてreturn。
※この際、validate()を使用して、視聴チャンネルが1~12かつ合計視聴時間が0~1440の範囲外であった場合、エラー表示してプログラムを終了するようにしています。

■各項目を表示させる
・display()を使用して、下記のように処理後①合計視聴時間（hour表示）、②各チャンネル番号、視聴時間(分)、視聴回数をそれぞれ表示させてます。
①合計視聴時間（hour表示）
合計視聴時間をhour表示させるため、$total_view_timeを60で割り、round()にて小数点第一位までを表示させてます。
②チャンネル番号、視聴時間、視聴回数
・$channel_time_pairsに対して、foreach,list()を使用して各要素を取り出して$resultに取り出した値を格納しています。
・このとき、isset()を使用することで、同じチャンネル番号が出現した際に、視聴時間および視聴回数を更新させるのではなく、足す処理に条件分岐させています。
・ksort()を使用することで、$resultのkey、つまり視聴チャンネル番号を昇順に並び替えて、表示を見やすくしています。


