### PR TITLE
単一責任の原則に沿って、ポーカーカードプログラムをリファクタリングしました。

### DIFF
--- a/src/lib/poker/Card.php
+++ b/src/lib/poker/Card.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace poker;
+
+class Card
+{
+  private const CardRanks = [
+    '2' => 1,
+    '3' => 2,
+    '4' => 3,
+    '5' => 4,
+    '6' => 5,
+    '7' => 6,
+    '8' => 7,
+    '9' => 8,
+    '10' => 9,
+    'J' => 10,
+    'Q' => 11,
+    'K' => 12,
+    'A' => 13
+  ];
+
+  private $suit;
+  private $number = [];
+
+  public function __construct(private array $cards)
+  {
+    $this->suit = array_map(fn($card) => mb_substr($card, 0, 1), $this->cards);
+    $numbers = array_map(fn($card) => mb_substr($card, 1, strlen($card) - 1), $this->cards);
+    foreach ($numbers as $number) {
+      $this->number[] = self::CardRanks[$number];
+    }
+  }
+
+  public function getNumber(): array
+  {
+    return $this->number;
+  }
+  public function getSuit(): array
+  {
+    return $this->suit;
+  }
+}

--- a/src/lib/poker/Player.php
+++ b/src/lib/poker/Player.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace poker;
+
+require_once('Card.php');
+class Player
+{
+  public function __construct(private Card $cards) {}
+
+  public function getNumber()
+  {
+    return $this->cards->getNumber();
+  }
+  public function getSuit()
+  {
+    return $this->cards->getSuit();
+  }
+}

--- a/src/lib/poker/PokerGame.php
+++ b/src/lib/poker/PokerGame.php
@@ -1,11 +1,22 @@
 <?php
 
+namespace poker;
+
+require_once('Card.php');
+require_once('Player.php');
+
 class PokerGame
 {
   public function __construct(private array $cards1, private array $cards2) {}
 
   public function start(): array
   {
-    return [$this->cards1, $this->cards2];
+    $playerRanks = [];
+    foreach ([$this->cards1, $this->cards2] as $cards) {
+      $playerCard = new Card($cards);
+      $player = new Player($playerCard);
+      $playerRanks[] = $player->getNumber();
+    }
+    return $playerRanks;
   }
 }

--- a/src/tests/poker/CardTest.php
+++ b/src/tests/poker/CardTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace poker;
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '../../../lib/poker/Card.php');
+
+class CardTest extends TestCase
+{
+  public function testGetNumber()
+  {
+    $card = new Card(['H10', 'SA']);
+    $this->assertSame([9, 13], $card->getNumber());
+  }
+  public function testGetSuit()
+  {
+    $card = new Card(['H10', 'SA']);
+    $this->assertSame(['H', 'S'], $card->getSuit());
+  }
+}

--- a/src/tests/poker/PlayerTest.php
+++ b/src/tests/poker/PlayerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace poker;
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '../../../lib/poker/Player.php');
+
+class PlayerTest extends TestCase
+{
+  public function testGetNumber()
+  {
+    $card = new Card(['H10', 'SA']);
+    $player = new Player($card);
+    $this->assertSame([9, 13], $player->getNumber());
+  }
+  public function testGetSuit()
+  {
+    $card = new Card(['H10', 'SA']);
+    $player = new Player($card);
+    $this->assertSame(['H', 'S'], $card->getSuit());
+  }
+}

--- a/src/tests/poker/PokerGameTest.php
+++ b/src/tests/poker/PokerGameTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace poker;
+
 use PHPUnit\Framework\TestCase;
 
 require_once(__DIR__ . '../../../lib/poker/PokerGame.php');
@@ -9,6 +11,6 @@ class PokerGameTest extends TestCase
   public function testStart()
   {
     $game = new PokerGame(['CA', 'DA'], ['C10', 'H10']);
-    $this->assertSame([['CA', 'DA'], ['C10', 'H10']], $game->start());
+    $this->assertSame([[13, 13], [9, 9]], $game->start());
   }
 }


### PR DESCRIPTION
PorkerGame.phpのみで構成されていたプログラムを単一責任の原則に沿ってリファクタリングしました。
■Cardクラスの作成
・引いたカードを引数として受取り、カードのマーク4種類のいずれか（suit）および1~13までのカードの強さ(number)を
プロパティとして持つCardクラスを作成。このオブジェクトをPlayerクラスの引数に渡すことで、各々のプレイヤーがCardクラスのプロパティ(suit,number)を保持することができます。
■Playerクラスの作成
・プレイヤー情報を登録するPlayerクラスを作成。
・numberプロパティの値を取得するgetNumber()およびsuitプロパティを取得するgetSuit()では、CardクラスのgetNumber()およびgetSuit()を呼び出しています。Playerクラスからはsuitおよびnumberのプロパティ値が取得さえできればよいので、これら関数のロジックを知る必要はなく、Cardクラスに依存していない状態となっております。

作成したPokerGame.phpでは、一旦、プレイヤー1およびプレイヤー2が引いたカードの強さを配列としてreturnさせております。
