### PR TITLE
ツーカードポーカーを単一責任の原則に沿ってリファクタリングしました。

### DIFF
--- a/src/lib/poker/Card.php
+++ b/src/lib/poker/Card.php
@@ -4,7 +4,7 @@ namespace poker;
 
 class Card
 {
-  private const CardRanks = [
+  public const CARD_RANKS = [
     '2' => 1,
     '3' => 2,
     '4' => 3,
@@ -28,7 +28,7 @@ class Card
     $this->suit = array_map(fn($card) => mb_substr($card, 0, 1), $this->cards);
     $numbers = array_map(fn($card) => mb_substr($card, 1, strlen($card) - 1), $this->cards);
     foreach ($numbers as $number) {
-      $this->number[] = self::CardRanks[$number];
+      $this->number[] = self::CARD_RANKS[$number];
     }
   }
 

--- a/src/lib/poker/HandEvaluator.php
+++ b/src/lib/poker/HandEvaluator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace poker;
+
+require_once('Rule.php');
+
+class HandEvaluator
+{
+  public function __construct(private Rule $rule) {}
+
+  public function getHand(array $card): string
+  {
+    return $this->rule->getHand($card);
+  }
+}

--- a/src/lib/poker/PokerGame.php
+++ b/src/lib/poker/PokerGame.php
@@ -2,8 +2,10 @@
 
 namespace poker;
 
+require_once('Rule.php');
 require_once('Card.php');
 require_once('Player.php');
+require_once('HandEvaluator.php');
 
 class PokerGame
 {
@@ -11,12 +13,15 @@ class PokerGame
 
   public function start(): array
   {
-    $playerRanks = [];
+    $rule = new RuleA();
+    $playerHands = [];
     foreach ([$this->cards1, $this->cards2] as $cards) {
       $playerCard = new Card($cards);
       $player = new Player($playerCard);
-      $playerRanks[] = $player->getNumber();
+      $cardRank = $player->getNumber();
+      $handEvaluator = new HandEvaluator($rule);
+      $playerHands[] = $handEvaluator->getHand($cardRank);
     }
-    return $playerRanks;
+    return $playerHands;
   }
 }

--- a/src/lib/poker/Rule.php
+++ b/src/lib/poker/Rule.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace poker;
+
+interface Rule
+{
+  public function isMinMax(array $card): bool;
+  public function isStraight(array $card): bool;
+  public function isPair(array $card): bool;
+  public function getHand(array $card): string;
+}

--- a/src/lib/poker/RuleA.php
+++ b/src/lib/poker/RuleA.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace poker;
+
+require_once('Card.php');
+require_once('Rule.php');
+
+class RuleA implements Rule
+{
+  private const HIGH_CARD = 'high card';
+  private const PAIR = 'pair';
+  private const STRAIGHT = 'straight';
+
+  public function getHand(array $card): string
+  {
+    $hand = self::HIGH_CARD;
+    if ($this->isStraight($card)) {
+      $hand = self::STRAIGHT;
+    }
+    if ($this->isPair($card)) {
+      $hand = self::PAIR;
+    }
+    return $hand;
+  }
+
+  public function isMinMax(array $card): bool
+  {
+    if (abs($card[0] - $card[1]) === (max(Card::CARD_RANKS) - min(Card::CARD_RANKS))) {
+      return true;
+    }
+    return false;
+  }
+  public function isStraight(array $card): bool
+  {
+    if (abs($card[0] - $card[1]) === 1 || $this->isMinMax($card)) {
+      return true;
+    }
+    return false;
+  }
+
+  public function isPair(array $card): bool
+  {
+    if (count(array_count_values($card)) === 1) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/tests/poker/HandEvaluatorTest.php
+++ b/src/tests/poker/HandEvaluatorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace poker;
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '../../../lib/poker/HandEvaluator.php');
+require_once(__DIR__ . '../../../lib/poker/Rule.php');
+
+class HandEvaluatorTest extends TestCase
+{
+  public function testGetHand()
+  {
+    $rule = new RuleA();
+    $handEvaluator = new HandEvaluator($rule);
+    $this->assertSame('high card', $handEvaluator->getHand([1, 3]));
+    $this->assertSame('pair', $handEvaluator->getHand([1, 1]));
+    $this->assertSame('straight', $handEvaluator->getHand([2, 1]));
+    $this->assertSame('straight', $handEvaluator->getHand([13, 1]));
+    $this->assertSame('straight', $handEvaluator->getHand([13, 12]));
+  }
+}

--- a/src/tests/poker/PokerGameTest.php
+++ b/src/tests/poker/PokerGameTest.php
@@ -10,7 +10,7 @@ class PokerGameTest extends TestCase
 {
   public function testStart()
   {
-    $game = new PokerGame(['CA', 'DA'], ['C10', 'H10']);
-    $this->assertSame([[13, 13], [9, 9]], $game->start());
+    $game = new PokerGame(['CA', 'DA'], ['CA', 'H2']);
+    $this->assertSame(['pair', 'straight'], $game->start());
   }
 }

--- a/src/tests/poker/RuleATest.php
+++ b/src/tests/poker/RuleATest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace poker;
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '../../../lib/poker/RuleA.php');
+
+class RuleATest extends TestCase
+{
+  public function testGetHand()
+  {
+    $rule = new RuleA();
+    $this->assertSame('high card', $rule->getHand([1, 3]));
+    $this->assertSame('pair', $rule->getHand([1, 1]));
+    $this->assertSame('straight', $rule->getHand([2, 1]));
+    $this->assertSame('straight', $rule->getHand([13, 1]));
+    $this->assertSame('straight', $rule->getHand([13, 12]));
+  }
+}


### PR DESCRIPTION
■変更点
・役の判定を行うHandEvaluatorクラスを作成し、役の判定ルールを持っているRuleAクラス（Rule interfaceを継承implementsさせたクラス）をそれぞれ作成しました。

◯HandEvaluatorクラス
・インスタンス生成時に引数にRuleオブジェクトを受取り、RuleクラスのgetHand()メソッドを使用することにより、Ruleオブジェクトに応じた役の判定処理を行うようにしております。
今後、役の判定ルールが追加された際に、RuleA以外を作成することで仕様変更に柔軟に対応できるように実装しております。

◯RuleAクラス
・RuleAクラスでは、getHand()メソッドの引数に受け取ったカードの配列を条件分岐させて、high card、pair、straightいずれかをreturnさせております。