### PR TITLE
継承を用いて$Ruleに応じて2カードポーカーと3カードポーカーを切り替えて処理できるようにしました。

### DIFF
--- a/src/lib/poker/PokerGame.php
+++ b/src/lib/poker/PokerGame.php
@@ -2,7 +2,8 @@
 
 namespace poker;
 
-require_once('Rule.php');
+require_once('TwoCardPOkerRule.php');
+require_once('ThreeCardPOkerRule.php');
 require_once('Card.php');
 require_once('Player.php');
 require_once('HandEvaluator.php');
@@ -13,7 +14,7 @@ class PokerGame
 
   public function start(): array
   {
-    $rule = new RuleA();
+    $rule = $this->getUseCardNumber();
     $playerHands = [];
     foreach ([$this->cards1, $this->cards2] as $cards) {
       $playerCard = new Card($cards);
@@ -23,5 +24,14 @@ class PokerGame
       $playerHands[] = $handEvaluator->getHand($cardRank);
     }
     return $playerHands;
+  }
+
+  private function getUseCardNumber()
+  {
+    $rule = new TwoCardPokerRule();
+    if (count($this->cards1) === 3) {
+      $rule = new ThreeCardPokerRule();
+    }
+    return $rule;
   }
 }

--- a/src/lib/poker/ThreeCardPokerRule.php
+++ b/src/lib/poker/ThreeCardPokerRule.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace poker;
+
+require_once('Card.php');
+require_once('Rule.php');
+
+class ThreeCardPokerRule implements Rule
+{
+  private const HIGH_CARD = 'high card';
+  private const PAIR = 'pair';
+  private const STRAIGHT = 'straight';
+  private const THREE_OF_KIND = 'three of a kind';
+
+  public function getHand(array $card): string
+  {
+    $hand = self::HIGH_CARD;
+    rsort($card);
+
+    if ($this->isThreeOfKind($card)) {
+      $hand = self::THREE_OF_KIND;
+    }
+    if ($this->isStraight($card)) {
+      $hand = self::STRAIGHT;
+    }
+    if ($this->isPair($card)) {
+      $hand = self::PAIR;
+    }
+    return $hand;
+  }
+
+  public function isThreeOfKind(array $card): bool
+  {
+    if (count(array_count_values($card)) === 1) {
+      return true;
+    }
+    return false;
+  }
+  public function isContinuous(array $card): bool
+  {
+    if ($card[2] + 1 ===  $card[1] && $card[0] - 1 === $card[1]) {
+      return true;
+    }
+    return false;
+  }
+  public function isMinMax(array $card): bool
+  {
+    if (abs(max($card) - min($card)) === (max(Card::CARD_RANKS) - min(Card::CARD_RANKS)) && (min($card) + 1) === $card[1]) {
+      return true;
+    }
+    return false;
+  }
+  public function isStraight(array $card): bool
+  {
+    if ($this->isContinuous($card) || $this->isMinMax($card)) {
+      return true;
+    }
+    return false;
+  }
+
+  public function isPair(array $card): bool
+  {
+    if (count(array_count_values($card)) === 2) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/lib/poker/TwoCardPokerRule.php
+++ b/src/lib/poker/TwoCardPokerRule.php
@@ -5,16 +5,16 @@ namespace poker;
 require_once('Card.php');
 require_once('Rule.php');
 
-class RuleA implements Rule
+class TwoCardPokerRule implements Rule
 {
   private const HIGH_CARD = 'high card';
   private const PAIR = 'pair';
   private const STRAIGHT = 'straight';
 
-  public function getHand(array $card): string
+  public function getHand(Card $card): string
   {
     $hand = self::HIGH_CARD;
-    if ($this->isStraight($card)) {
+    if ($this->isStraight($this->card)) {
       $hand = self::STRAIGHT;
     }
     if ($this->isPair($card)) {

--- a/src/tests/poker/HandEvaluatorTest.php
+++ b/src/tests/poker/HandEvaluatorTest.php
@@ -11,12 +11,22 @@ class HandEvaluatorTest extends TestCase
 {
   public function testGetHand()
   {
-    $rule = new RuleA();
+    // カードが2枚の場合
+    $rule = new TwoCardPokerRule();
     $handEvaluator = new HandEvaluator($rule);
     $this->assertSame('high card', $handEvaluator->getHand([1, 3]));
     $this->assertSame('pair', $handEvaluator->getHand([1, 1]));
     $this->assertSame('straight', $handEvaluator->getHand([2, 1]));
     $this->assertSame('straight', $handEvaluator->getHand([13, 1]));
     $this->assertSame('straight', $handEvaluator->getHand([13, 12]));
+    // カードが3枚の場合
+    $rule = new ThreeCardPokerRule();
+    $handEvaluator = new HandEvaluator($rule);
+    $this->assertSame('high card', $handEvaluator->getHand([1, 12, 13]));
+    $this->assertSame('pair', $handEvaluator->getHand([1, 1, 3]));
+    $this->assertSame('straight', $handEvaluator->getHand([2, 1, 3]));
+    $this->assertSame('straight', $handEvaluator->getHand([13, 1, 2]));
+    $this->assertSame('straight', $handEvaluator->getHand([13, 12, 11]));
+    $this->assertSame('three of a kind', $handEvaluator->getHand([1, 1, 1]));
   }
 }

--- a/src/tests/poker/PokerGameTest.php
+++ b/src/tests/poker/PokerGameTest.php
@@ -10,7 +10,12 @@ class PokerGameTest extends TestCase
 {
   public function testStart()
   {
-    $game = new PokerGame(['CA', 'DA'], ['CA', 'H2']);
-    $this->assertSame(['pair', 'straight'], $game->start());
+    // カードが2枚の場合
+    $game1 = new PokerGame(['CA', 'DA'], ['C9', 'H10']);
+    $this->assertSame(['pair', 'straight'], $game1->start());
+
+    // カードが3枚の場合
+    $game2 = new PokerGame(['C2', 'D2', 'S2'], ['CQ', 'HA', 'DK']);
+    $this->assertSame(['three of a kind', 'straight'], $game2->start());
   }
 }

--- a/src/tests/poker/ThreeCardPokerRule.php
+++ b/src/tests/poker/ThreeCardPokerRule.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace poker;
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '../../../lib/poker/ThreeCardPokerRule.php');
+
+class ThreeCardPokerRuleTest extends TestCase
+{
+  public function testGetHand()
+  {
+    $rule = new ThreeCardPokerRule();
+    $this->assertSame('high card', $rule->getHand([1, 12, 13]));
+    $this->assertSame('high card', $rule->getHand([1, 12, 13]));
+    $this->assertSame('pair', $rule->getHand([1, 1, 3]));
+    $this->assertSame('straight', $rule->getHand([2, 1, 3]));
+    $this->assertSame('straight', $rule->getHand([13, 1, 2]));
+    $this->assertSame('straight', $rule->getHand([13, 12, 11]));
+    $this->assertSame('three of a kind', $rule->getHand([1, 1, 1]));
+  }
+}

--- a/src/tests/poker/TwoCardPokerRule.php
+++ b/src/tests/poker/TwoCardPokerRule.php
@@ -4,13 +4,13 @@ namespace poker;
 
 use PHPUnit\Framework\TestCase;
 
-require_once(__DIR__ . '../../../lib/poker/RuleA.php');
+require_once(__DIR__ . '../../../lib/poker/TwoCardPokerRule.php');
 
-class RuleATest extends TestCase
+class TwoCardPokerRuleTest extends TestCase
 {
   public function testGetHand()
   {
-    $rule = new RuleA();
+    $rule = new TwoCardPokerRule();
     $this->assertSame('high card', $rule->getHand([1, 3]));
     $this->assertSame('pair', $rule->getHand([1, 1]));
     $this->assertSame('straight', $rule->getHand([2, 1]));


### PR DESCRIPTION
■変更点
Ruleインターフェースをimplementsした
・TwoCardPokerRuleクラス(カード2枚使用時の役判定処理)
・ThreeCardPokerRuleクラス（カード3枚使用時の役判定処理）
をそれぞれ作成しました。
PokerGame.phpにてカードの枚数に応じて$ruleに上記いずれかのクラスを格納し、HandEvaluatorインスタンス生成時に
引数としてRuleクラスを渡すことで、役判定処理のgetRule()がカードが2枚の場合と3枚の場合とで処理が分かれるようにしております。