### PR TITLE
解答をもとに、自動販売機プログラムをリファクタリングしました。

### DIFF
--- a/src/lib/vending_machine/Snack.php
+++ b/src/lib/vending_machine/Snack.php
@@ -2,11 +2,11 @@
 
 require_once('Item.php');
 
-class PotatoChips extends Item
+class Snack extends Item
 {
   private const PRICES =
   [
-    'potatoChips' => 150
+    'potato chips' => 150
   ];
 
   public function __construct(string $name)

--- a/src/tests/vending_machine/PotatoChipsTest.php
+++ b/src/tests/vending_machine/PotatoChipsTest.php
@@ -2,24 +2,24 @@
 
 use PHPUnit\Framework\TestCase;
 
-require_once(__DIR__ . '../../../lib/vending_machine/PotatoChips.php');
+require_once(__DIR__ . '../../../lib/vending_machine/Snack.php');
 
 class PotatoChipsTest extends TestCase
 {
   public function testGetName()
   {
-    $potatoChips = new PotatoChips('potatoChips');
-    $this->assertSame('potatoChips', $potatoChips->getName());
+    $potatoChips = new Snack('potato chips');
+    $this->assertSame('potato chips', $potatoChips->getName());
   }
 
   public function testGetPrice()
   {
-    $potatoChips = new PotatoChips('potatoChips');
+    $potatoChips = new Snack('potato chips');
     $this->assertSame(150, $potatoChips->getPrice());
   }
   public function testGetCupNumber()
   {
-    $potatoChips = new PotatoChips('potatoChips');
+    $potatoChips = new Snack('potato chips');
     $this->assertSame(0, $potatoChips->getCupNumber());
   }
 }

--- a/src/tests/vending_machine/VendingMachineTest.php
+++ b/src/tests/vending_machine/VendingMachineTest.php
@@ -19,6 +19,7 @@ class VendingMachineTest extends TestCase
     $cider = new Drink('cider');
     $cola = new Drink('cola');
     $hotCupCoffee = new CupDrink('hot cup coffee');
+    $snack = new Snack('potato chips');
     $vendingMachine = new VendingMachine();
 
     # お金が投入されてない場合は購入できない
@@ -42,6 +43,10 @@ class VendingMachineTest extends TestCase
     // カップを入れた場合は購入できる
     $vendingMachine->addCup(1);
     $this->assertSame('hot cup coffee', $vendingMachine->pressButton($hotCupCoffee));
+
+    // スナックも購入できる
+    $vendingMachine->depositCoin(100);
+    $this->assertSame('potato chips', $vendingMachine->pressButton($snack));
   }
 
   public function testAddCup()


### PR DESCRIPTION
■主な変更点
・PotatoChipsクラスをSnackクラスに名前を変更
PotatoChipsクラスの名前がポテトチップス類の商品限定のクラスとして捉えられ兼ねないので、お菓子全体を表すSnackクラスに名前を変更しました。