### PR TITLE
カードの枚数が2,3,5枚それぞれの場合にて役判定の処理を動的に切り替えて処理できるようにしました。

### DIFF
--- a/src/lib/poker/FiveCardPokerRule.php
+++ b/src/lib/poker/FiveCardPokerRule.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace poker;
+
+require_once('Card.php');
+require_once('Rule.php');
+
+class FiveCardPokerRule implements Rule
+{
+  private const HIGH_CARD = 'high card';
+  private const ONE_PAIR = 'one pair';
+  private const TWO_PAIR = 'two pair';
+  private const STRAIGHT = 'straight';
+  private const THREE_OF_KIND = 'three of a kind';
+  private const FULL_HOUSE = 'full house';
+  private const FOUR_CARD = 'four of a kind';
+  private const SAME_NUMBER_IS_FOUR = 4;
+  private const SAME_NUMBER_IS_THREE = 3;
+  private const IDENTICAL_NUMBER_IS_TWO = 2;
+  private const ELEMENT_NUMBER_IS_THREE = 3;
+  private const ELEMENT_NUMBER_IS_FOUR = 4;
+
+  public function getHand(array $card): string
+  {
+    $hand = self::HIGH_CARD;
+    sort($card);
+    if ($this->isFourCard($card)) {
+      $hand = self::FOUR_CARD;
+    }
+    if ($this->isFullHouse($card)) {
+      $hand = self::FULL_HOUSE;
+    }
+    if ($this->isThreeOfKind($card)) {
+      $hand = self::THREE_OF_KIND;
+    }
+    if ($this->isStraight($card)) {
+      $hand = self::STRAIGHT;
+    }
+    if ($this->isTwoPair($card)) {
+      $hand = self::TWO_PAIR;
+    }
+    if ($this->isOnePair($card)) {
+      $hand = self::ONE_PAIR;
+    }
+    return $hand;
+  }
+
+  // カードの配列の要素数が2個かどうかを判定
+  private function isTwoArrayElements(array $card): bool
+  {
+    if (count(array_unique($card)) === 2) {
+      return true;
+    }
+    return false;
+  }
+
+  // 配列の要素の同じ番号の最大値を返す処理
+  private function getMaxSameNumber(array $card): int
+  {
+    return max(array_count_values($card));
+  }
+
+  public function isFourCard(array $card): bool
+  {
+    if ($this->isTwoArrayElements($card) && $this->getMaxSameNumber($card) === self::SAME_NUMBER_IS_FOUR) {
+      return true;
+    }
+    return false;
+  }
+
+  public function isFullHouse(array $card): bool
+  {
+    if ($this->isTwoArrayElements($card) && $this->getMaxSameNumber($card) === self::SAME_NUMBER_IS_THREE) {
+      return true;
+    }
+    return false;
+  }
+  public function isThreeOfKind(array $card): bool
+  {
+    if (!$this->isTwoArrayElements($card) && $this->getMaxSameNumber($card) === self::SAME_NUMBER_IS_THREE) {
+      return true;
+    }
+    return false;
+  }
+
+  // 配列の要素が連続した整数もしくは5-4-3-2-Aかどうかを判定
+  public function isContinuous(array $card): bool
+  {
+    if (range($card[0], $card[4], 1) ===  $card) {
+      return true;
+    }
+    if (range($card[0], $card[3], 1) === array_slice($card, 0, 4) && max($card) === max(Card::CARD_RANKS)) {
+      return true;
+    }
+    return false;
+  }
+
+  public function isStraight(array $card): bool
+  {
+    if ($this->isContinuous($card)) {
+      return true;
+    }
+    return false;
+  }
+
+  public function hasPair($card): bool
+  {
+    if (max(array_count_values($card)) === self::IDENTICAL_NUMBER_IS_TWO) {
+      return true;
+    }
+    return false;
+  }
+  public function isTwoPair(array $card): bool
+  {
+    if (count(array_unique($card)) === self::ELEMENT_NUMBER_IS_THREE && $this->hasPair($card)) {
+      return true;
+    }
+    return false;
+  }
+
+  public function isOnePair(array $card): bool
+  {
+    if (count(array_unique($card)) === self::ELEMENT_NUMBER_IS_FOUR && $this->hasPair($card)) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/lib/poker/PokerGame.php
+++ b/src/lib/poker/PokerGame.php
@@ -2,8 +2,9 @@
 
 namespace poker;
 
-require_once('TwoCardPOkerRule.php');
-require_once('ThreeCardPOkerRule.php');
+require_once('TwoCardPokerRule.php');
+require_once('ThreeCardPokerRule.php');
+require_once('FiveCardPokerRule.php');
 require_once('Card.php');
 require_once('Player.php');
 require_once('HandEvaluator.php');
@@ -29,6 +30,9 @@ class PokerGame
   private function getUseCardNumber()
   {
     $rule = new TwoCardPokerRule();
+    if (count($this->cards1) === 5) {
+      $rule = new FiveCardPokerRule();
+    }
     if (count($this->cards1) === 3) {
       $rule = new ThreeCardPokerRule();
     }

--- a/src/lib/poker/Rule.php
+++ b/src/lib/poker/Rule.php
@@ -4,8 +4,6 @@ namespace poker;
 
 interface Rule
 {
-  public function isMinMax(array $card): bool;
   public function isStraight(array $card): bool;
-  public function isPair(array $card): bool;
   public function getHand(array $card): string;
 }

--- a/src/lib/poker/ThreeCardPokerRule.php
+++ b/src/lib/poker/ThreeCardPokerRule.php
@@ -10,7 +10,7 @@ class ThreeCardPokerRule implements Rule
   private const HIGH_CARD = 'high card';
   private const PAIR = 'pair';
   private const STRAIGHT = 'straight';
-  private const THREE_OF_KIND = 'three of a kind';
+  private const THREE_CARD = 'three card';
 
   public function getHand(array $card): string
   {
@@ -18,7 +18,7 @@ class ThreeCardPokerRule implements Rule
     rsort($card);
 
     if ($this->isThreeOfKind($card)) {
-      $hand = self::THREE_OF_KIND;
+      $hand = self::THREE_CARD;
     }
     if ($this->isStraight($card)) {
       $hand = self::STRAIGHT;

--- a/src/tests/poker/FiveCardPokerRuleTest.php
+++ b/src/tests/poker/FiveCardPokerRuleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace poker;
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '../../../lib/poker/FiveCardPokerRule.php');
+
+class FiveCardPokerRuleTest extends TestCase
+{
+  public function testGetHand()
+  {
+    $rule = new FiveCardPokerRule();
+    $this->assertSame('high card', $rule->getHand([1, 12, 13, 2, 5]));
+    $this->assertSame('high card', $rule->getHand([13, 12, 3, 2, 1]));
+    $this->assertSame('high card', $rule->getHand([13, 11, 12, 2, 1]));
+    $this->assertSame('high card', $rule->getHand([13, 10, 11, 12, 1]));
+    $this->assertSame('one pair', $rule->getHand([1, 1, 3, 5, 6]));
+    $this->assertSame('two pair', $rule->getHand([2, 2, 8, 8, 6]));
+    $this->assertSame('straight', $rule->getHand([2, 1, 3, 5, 4]));
+    $this->assertSame('straight', $rule->getHand([9, 10, 11, 12, 13]));
+    $this->assertSame('straight', $rule->getHand([13, 4, 3, 2, 1]));
+    $this->assertSame('three of a kind', $rule->getHand([1, 1, 1, 6, 9]));
+    $this->assertSame('four of a kind', $rule->getHand([1, 1, 1, 1, 9]));
+    $this->assertSame('full house', $rule->getHand([1, 1, 1, 9, 9]));
+  }
+}

--- a/src/tests/poker/HandEvaluatorTest.php
+++ b/src/tests/poker/HandEvaluatorTest.php
@@ -27,6 +27,22 @@ class HandEvaluatorTest extends TestCase
     $this->assertSame('straight', $handEvaluator->getHand([2, 1, 3]));
     $this->assertSame('straight', $handEvaluator->getHand([13, 1, 2]));
     $this->assertSame('straight', $handEvaluator->getHand([13, 12, 11]));
-    $this->assertSame('three of a kind', $handEvaluator->getHand([1, 1, 1]));
+    $this->assertSame('three card', $handEvaluator->getHand([1, 1, 1]));
+
+    //カードが5枚の場合
+    $rule = new FiveCardPokerRule();
+    $handEvaluator = new HandEvaluator($rule);
+    $this->assertSame('high card', $handEvaluator->getHand([1, 12, 13, 2, 5]));
+    $this->assertSame('high card', $handEvaluator->getHand([13, 12, 3, 2, 1]));
+    $this->assertSame('high card', $handEvaluator->getHand([13, 11, 12, 2, 1]));
+    $this->assertSame('high card', $handEvaluator->getHand([13, 10, 11, 12, 1]));
+    $this->assertSame('one pair', $handEvaluator->getHand([1, 1, 3, 5, 6]));
+    $this->assertSame('two pair', $handEvaluator->getHand([2, 2, 8, 8, 6]));
+    $this->assertSame('straight', $handEvaluator->getHand([2, 1, 3, 5, 4]));
+    $this->assertSame('straight', $handEvaluator->getHand([9, 10, 11, 12, 13]));
+    $this->assertSame('straight', $handEvaluator->getHand([13, 4, 3, 2, 1]));
+    $this->assertSame('three of a kind', $handEvaluator->getHand([1, 1, 1, 6, 9]));
+    $this->assertSame('four of a kind', $handEvaluator->getHand([1, 1, 1, 1, 9]));
+    $this->assertSame('full house', $handEvaluator->getHand([1, 1, 1, 9, 9]));
   }
 }

--- a/src/tests/poker/PokerGameTest.php
+++ b/src/tests/poker/PokerGameTest.php
@@ -16,6 +16,10 @@ class PokerGameTest extends TestCase
 
     // カードが3枚の場合
     $game2 = new PokerGame(['C2', 'D2', 'S2'], ['CQ', 'HA', 'DK']);
-    $this->assertSame(['three of a kind', 'straight'], $game2->start());
+    $this->assertSame(['three card', 'straight'], $game2->start());
+
+    // カードが5枚の場合
+    $game2 = new PokerGame(['C2', 'D2', 'S2', 'H2', 'C3'], ['C10', 'H9', 'DK', 'DQ', 'SJ']);
+    $this->assertSame(['four of a kind', 'straight'], $game2->start());
   }
 }

--- a/src/tests/poker/ThreeCardPokerRule.php
+++ b/src/tests/poker/ThreeCardPokerRule.php
@@ -17,6 +17,6 @@ class ThreeCardPokerRuleTest extends TestCase
     $this->assertSame('straight', $rule->getHand([2, 1, 3]));
     $this->assertSame('straight', $rule->getHand([13, 1, 2]));
     $this->assertSame('straight', $rule->getHand([13, 12, 11]));
-    $this->assertSame('three of a kind', $rule->getHand([1, 1, 1]));
+    $this->assertSame('three card', $rule->getHand([1, 1, 1]));
   }
 }


### PR DESCRIPTION
ポーカーゲームプログラムにて、カードの枚数が2,3,5枚のそれぞれの場合にてHandEvaluatorクラスのgetHand()によるカードの役判定処理をカードの枚数に応じて切り替えられるようにしました。

◯PokerGame.php
・getRule()メソッドにて、カードの枚数が2,3,5枚かを条件分岐させて、枚数に応じてRuleオブジェクトを生成、$ruleに格納。
・生成した$ruleをHandEvaluatorクラスのインスタンス生成時に引数として渡すことで、HandEvaluatorインスタンスはgetRule()メソッドにて条件分岐・生成したRuleオブジェクトをプロパティとして持つことになります。
・HandEvaluatorクラスのgetHand()では、RuleオブジェクトのgetHand()を使用するため、HandEvaluatorクラスからは、RuleオブジェクトのgetHand()のロジックを知る必要はない状態となっております。これにより、HandEvaluatorクラスとRuleクラスは依存度の低い状態となっており、今後、役判定処理に仕様変更が生じた際、HandEvaluatorクラスへの影響を抑えることができます。

◯FiveCardPokerRule.php
・使用するカードが5枚の場合での役判定処理のロジックとなります。
・getHand($card)では、引いた5枚のカードのそれぞれのランクの値が配列として格納された$cardを引数として受け取っています。この$cardに対してgetHand()では、役判定の条件分岐処理を行うことで、$handに役名を格納させ、返しています。

■役判定の各条件分岐に関して
◯ハイカード
・getHand()の$handは初期値として'high card'を格納します。これにより、下記役判定の条件分岐にて処理が何もされなかった場合、getHand()では、$handは'high card'を返します。
◯フォーカード
4枚のカードが同じ数字を持つ役となります。
・isFourCard()による条件分岐で、isTwoArrayElements()かつgetMaxSameNumber()がtrueの場合、trueを返しております。
・isFourCard()がtrueの場合、getHand()では、$handに'four card'が格納され、falseの場合は何も処理されません。
・isTwoArrayElements()：配列の要素数が2つであるかを判定し、trueの場合は、trueを返し、falseの場合はfalseを返します。
・getMaxSameNumber():配列の要素にて要素の同じ値の最大出現回数を返す処理となります。isFourCard()では、getMaxSameNumber($card) === 4、つまり同じカードの番号が4つ存在しているかを判定しています。
◯フルハウス
3枚のカードが同じ数字を持ち、残りの2枚も同じ数字を持つ役となります。
・isFullHouse()による条件分岐で、isTwoArrayElements() === 2 かつgetMaxSameNumber() === 3がtrueの場合、trueを返してます。isFullHouse()がtrueの場合、getHand()では、$handに'full house'が格納され、falseの場合は何も処理されません。
・つまり、isTwoArrayElements() では、配列の要素数が2個であるかを判定し、getMaxSameNumber() では、同じ値の最大出現回数が3であるかを判定しております。
◯スリーカード
3枚のカードが同じ数字の役となります。
・isThreeOfKind()では、!isTwoArrayElements() === 2 かつgetMaxSameNumber() === 3がtrueの場合、trueを返してます。isThreeOfKind()がtrueの場合、getHand()では、$handに'three of a kind'が格納され、falseの場合は何も処理されません。
◯ストレート
5枚のカードが連続している役となります。A は2とKの両方と連続しているとみなし、Aを含むストレートは、下記2つです。
・A-K-Q-J-10
・5-4-3-2-A
※4-3-2-A-K、3-2-A-K-Q、2-A-K-Q-J のランクの組み合わせはストレートとはなりません。
・isStraight()では、isContinuous()がtrueの場合、trueを返してます。isStraight()がtrueの場合、getHand()では、$handに'straight'が格納され、falseの場合は何も処理されません。
・isContinuous():$cardの配列がrange関数を用いて、連続した値であるかを判定しています。
　・一つ目のif文では、配列内の5つの値が連続した値であるかを判定しています。
　・２つ目のif文では、配列内の先頭から4つの値が連続した値であり、かつ、配列の要素の最大値がカードの最大の強さと一致しているかを判定しています。この処理では、配列の値が5-4-3-2-Aであった場合にtrueを返す処理となっております。
◯ツーペア
2枚のカードが同じ数字であるのを2組持つ役となります。
・isTwoPair()では、配列の要素数が3個かつ、hasPair()がtrueの場合にtrueを返す処理となります。isTwoPair()がtrueの場合、getHand()では、$handに'twoPair'が格納され、falseの場合は何も処理されません。
・hasPair():配列内の要素の最大出現回数が2の場合、trueを返し、そうでない場合はfalseを返す処理となります。
ツーペアの条件として、異なるカード番号の出現は3個で、同じカード番号を持つカードの枚数は最大2枚であることのため、上記条件処理としております。
◯ワンペア
2枚のカードが同じ数字であるのを1組持つ役となります。
・isOnePair()では、配列の要素数が4個かつ、hasPair()がtrueの場合にtrueを返す処理となります。isOnePair()がtrueの場合、getHand()では、$handに'onePair'が格納され、falseの場合は何も処理されません。
・hasPair():配列内の要素の最大出現回数が2の場合、trueを返し、そうでない場合はfalseを返す処理となります。
ツーペアの条件として、異なるカード番号の出現は4個で、同じカード番号を持つカードの枚数は最大2枚であることのため、上記条件処理としております。

