### PR TITLE
解答をもとに、isContinuous()、isOnePair()をリファクタリングしました。

### DIFF
--- a/src/lib/poker/FiveCardPokerRule.php
+++ b/src/lib/poker/FiveCardPokerRule.php
@@ -86,10 +86,10 @@ class FiveCardPokerRule implements Rule
   // 配列の要素が連続した整数もしくは5-4-3-2-Aかどうかを判定
   public function isContinuous(array $card): bool
   {
-    if (range($card[0], $card[4], 1) ===  $card) {
+    if (range($card[0], $card[0] + count($card) - 1) ===  $card) {
       return true;
     }
-    if (range($card[0], $card[3], 1) === array_slice($card, 0, 4) && max($card) === max(Card::CARD_RANKS)) {
+    if (range($card[0], $card[0] + count($card) - 2) === array_slice($card, 0, 4) && max($card) === max(Card::CARD_RANKS)) {
       return true;
     }
     return false;
@@ -120,7 +120,7 @@ class FiveCardPokerRule implements Rule
 
   public function isOnePair(array $card): bool
   {
-    if (count(array_unique($card)) === self::ELEMENT_NUMBER_IS_FOUR && $this->hasPair($card)) {
+    if (count(array_unique($card)) === self::ELEMENT_NUMBER_IS_FOUR) {
       return true;
     }
     return false;


### PR DESCRIPTION
◯isContinuous()
・range関数のロジックを一部変更。
・1つ目のif文では、range関数の第二引数を配列の要素数-1、つまり4とすることで、range関数では、$cardの要素番号0の値に4を足した数字までを連続した数字として返す処理とし、コードを見やすくしております。
・2つ目のif文では、range関数の第二引数を配列の要素数-2、つまり3とすることで、range関数では、$cardの要素番号0の値に3を足した数字までを連続した数字として返す処理とし、コードを見やすくしております。
◯isOnePair()
・ワンペアの役判定において、hasPair()が不要だったため、削除しております。