### PR TITLE
例外処理の学習として、Exception.phpを作成。

### DIFF
--- a/src/sample/Exception.php
+++ b/src/sample/Exception.php
@@ -1,0 +1,31 @@
+<?php
+
+class CurrencyCal
+{
+
+  const CURRENCIES =
+  [
+    'dollar',
+    'pound'
+  ];
+
+  public static function calculateToYen($amount, $currency)
+  {
+    try {
+      self::convert($amount, $currency);
+    } catch (Exception $e) {
+      echo '例外: ' . $e->getMessage() . PHP_EOL;
+    }
+  }
+
+  private static function convert($amount, $currency)
+  {
+    if (!in_array($currency, self::CURRENCIES)) {
+      throw new Exception('対応していない通貨です');
+    }
+    echo $amount . '円を' . $currency . 'に変換します' . PHP_EOL;
+  }
+}
+
+CurrencyCal::calculateToYen(100, 'dollar');
+// CurrencyCal::calculateToYen(100, 'won');


### PR DESCRIPTION
例外処理の学習として、try catch構文を使用して、例外処理を仮実装したException.phpを作成。
Exception.phpでは、CurrencyCal::calculateToYen()メソッドの第2引数として受け取った文字列が
・dollar
・pound
のいずれかの場合は、正常に処理が行われ、それ以外の値を受け取った場合は、例外処理として
・throw new Exception()の引数として渡した'対応していない通貨です'がエラーメッセージとして渡され、
$e->getMessageとして出力されます。