### PR TITLE
プレイヤーのカードの合計値が22を超えている場合、ディーラーはカードを追加しない処理を実装

### DIFF
--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -29,7 +29,9 @@ class Game
     $dealer->firstGetCardMessage();
     $player->selectCardAddOrNot($deck);
     $dealer->displaySecondCardMessage();
-    $dealer->selectCardAddOrNot($deck);
+    if ($player->getTotalCardsNumber() < $deck->getBustNumber()) {
+      $dealer->selectCardAddOrNot($deck);
+    }
     $deck->judgeTheWinner($player, $dealer);
 
     return 1;


### PR DESCRIPTION
Game.phpにてプレイヤーのカードの合計値が22を超えている場合、Dealerオブジェクトはカードを追加しない処理を実装しました。この修正により、プレイヤーのカードの合計値が22を超えていても、ディーラーがカードを追加することがないようになりました。