### PR TITLE
手札の合計値が21を最大値となるよう、Aが1もしくは11に変わるよう仕様変更しました。

### DIFF
--- a/src/lib/black_jack/CardRule.php
+++ b/src/lib/black_jack/CardRule.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BlackJack;
+
+require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
+
+abstract class CardRule
+{
+  abstract public function drawCard(array $cards): array;
+  abstract public function getRank(int|string $drawnCard): int;
+  abstract public function calculateTotalCardNumber(array $hands): array;
+  abstract public function getBustNumber(): int;
+  abstract public function judgeTheWinner(Player $player, Dealer $dealer): string;
+  abstract protected function isPush(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool;
+  abstract protected function isWin(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool;
+  abstract protected function isLoss(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool;
+}

--- a/src/lib/black_jack/CardRuleA.php
+++ b/src/lib/black_jack/CardRuleA.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace BlackJack;
+
+require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRule.php');
+
+class CardRuleA extends CardRule
+{
+  const CARD_RANKS =
+  [
+    'A' => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4,
+    5 => 5,
+    6 => 6,
+    7 => 7,
+    8 => 8,
+    9 => 9,
+    10 => 10,
+    'J' => 10,
+    'Q' => 10,
+    'K' => 10,
+  ];
+  const BUST_NUMBER = 22;
+
+  public function drawCard(array $cards): array
+  {
+    $cards[0]['cardRank'] = $this->getRank($cards[0]['number']);
+    return $cards[0];
+  }
+
+  public function getRank(int|string $drawnCard): int
+  {
+    return self::CARD_RANKS[$drawnCard];
+  }
+
+  public function calculateTotalCardNumber(array $hands): array
+  {
+    $sum = array_sum(array_column($hands, 'cardRank'));
+    return [$hands, $sum];
+  }
+
+  public function getBustNumber(): int
+  {
+    return self::BUST_NUMBER;
+  }
+
+  public function judgeTheWinner(Player $player, Dealer $dealer): string
+  {
+    $playerTotalCardsNumber = $player->displayTotalCardsNumber();
+    $dealerTotalCardsNumber = $dealer->displayTotalCardsNumber();
+    if ($this->isPush($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
+      return '引き分けです。' . PHP_EOL;
+    } elseif ($this->isWin($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
+      return  $player->getName() . 'の勝ちです!' . PHP_EOL;
+    } elseif ($this->isLoss($playerTotalCardsNumber, $dealerTotalCardsNumber))
+      return $player->getName() . 'の負けです。' . PHP_EOL;
+  }
+
+  protected function isPush(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
+  {
+    if ($playerTotalCardsNumber >= self::BUST_NUMBER && $dealerTotalCardsNumber >= self::BUST_NUMBER) {
+      return true;
+    } elseif ($playerTotalCardsNumber === $dealerTotalCardsNumber) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  protected function isWin(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
+  {
+    if ($playerTotalCardsNumber < self::BUST_NUMBER) {
+      if ($playerTotalCardsNumber > $dealerTotalCardsNumber || $dealerTotalCardsNumber >= self::BUST_NUMBER) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected function isLoss(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
+  {
+    if ($dealerTotalCardsNumber < self::BUST_NUMBER) {
+      if ($playerTotalCardsNumber < $dealerTotalCardsNumber || $playerTotalCardsNumber >= self::BUST_NUMBER) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/lib/black_jack/CardRuleB.php
+++ b/src/lib/black_jack/CardRuleB.php
@@ -4,11 +4,11 @@ namespace BlackJack;
 
 require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
 
-class Card
+class CardRuleB extends CardRule
 {
   const CARD_RANKS =
   [
-    'A' => 1,
+    'A' => 11,
     2 => 2,
     3 => 3,
     4 => 4,
@@ -22,19 +22,30 @@ class Card
     'Q' => 10,
     'K' => 10,
   ];
-  const BUST_NUMBER = 22;
 
-  // private string $suit;
-  // private int|string $number;
+  const BUST_NUMBER = 22;
 
   public function drawCard(array $cards): array
   {
+    $cards[0]['cardRank'] = $this->getRank($cards[0]['number']);
     return $cards[0];
   }
 
   public function getRank(int|string $drawnCard): int
   {
     return self::CARD_RANKS[$drawnCard];
+  }
+
+  public function calculateTotalCardNumber(array $hands): array
+  {
+    $sum = array_sum(array_column($hands, 'cardRank'));
+    foreach ($hands as &$hand) {
+      if ($hand['cardRank'] === 11 && $sum >= 22) {
+        $hand['cardRank'] = 1;
+        $sum -= 10;
+      }
+    }
+    return [$hands, $sum];
   }
 
   public function getBustNumber(): int
@@ -54,7 +65,7 @@ class Card
       return $player->getName() . 'の負けです。' . PHP_EOL;
   }
 
-  private function isPush(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
+  protected function isPush(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
   {
     if ($playerTotalCardsNumber >= self::BUST_NUMBER && $dealerTotalCardsNumber >= self::BUST_NUMBER) {
       return true;
@@ -65,7 +76,7 @@ class Card
     }
   }
 
-  private function isWin(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
+  protected function isWin(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
   {
     if ($playerTotalCardsNumber < self::BUST_NUMBER) {
       if ($playerTotalCardsNumber > $dealerTotalCardsNumber || $dealerTotalCardsNumber >= self::BUST_NUMBER) {
@@ -75,7 +86,7 @@ class Card
     return false;
   }
 
-  private function isLoss(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
+  protected function isLoss(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool
   {
     if ($dealerTotalCardsNumber < self::BUST_NUMBER) {
       if ($playerTotalCardsNumber < $dealerTotalCardsNumber || $playerTotalCardsNumber >= self::BUST_NUMBER) {
@@ -84,16 +95,4 @@ class Card
     }
     return false;
   }
-
-
-
-  // public function getSuit(): string
-  // {
-  //   return $this->suit;
-  // }
-
-  // public function getNumber(): int|string
-  // {
-  //   return $this->number;
-  // }
 }

--- a/src/lib/black_jack/Dealer.php
+++ b/src/lib/black_jack/Dealer.php
@@ -20,9 +20,14 @@ class Dealer extends User
   public function drawCard(Deck $deck): array
   {
     $drawnCard = $deck->drawCard();
-    $this->totalCardsNumber += $deck->getRank($drawnCard['number']);
     $this->hands[] = $drawnCard;
+    $this->calculateTotalCardNumber($this->hands, $deck);
     return $this->hands;
+  }
+
+  protected function calculateTotalCardNumber(array $hands, Deck $deck): void
+  {
+    list($this->hands, $this->totalCardsNumber) = $deck->calculateTotalCardNumber($hands);
   }
 
   public function selectCardAddOrNot(Deck $deck): void
@@ -33,7 +38,6 @@ class Dealer extends User
       $this->lastGetCardMessage();
     }
   }
-
 
   public function getTotalCardsNumber(): int
   {
@@ -74,8 +78,8 @@ class Dealer extends User
   }
 
   //　テストコードのみに使用するメソッド
-  public function setHand(string $suit, int $number): void
+  public function setHand(string $suit, int $number, int $cardRank): void
   {
-    $this->hands[] =  ['suit' => $suit, 'number'  => $number];
+    $this->hands[] =  ['suit' => $suit, 'number'  => $number, 'cardRank' => $cardRank];
   }
 }

--- a/src/lib/black_jack/Deck.php
+++ b/src/lib/black_jack/Deck.php
@@ -2,16 +2,16 @@
 
 namespace BlackJack;
 
-use BlackJack\Card;
+require_once(__DIR__ . '../../../lib/black_jack/CardRule.php');
 
-require_once(__DIR__ . '../../../lib/black_jack/Card.php');
+use BlackJack\CardRule;
 
 class Deck
 {
 
   private array $cards = [];
 
-  public function __construct(private Card $card = new Card())
+  public function __construct(private CardRule $cardRule)
   {
     // ジョーカーを除く52枚のカードを生成しシャッフルする
     foreach (['ハート', 'スペード', 'ダイヤ', 'クラブ'] as $suit) {
@@ -35,24 +35,30 @@ class Deck
   public function drawCard(): array
   {
     // カードの配列より1枚目を取り出し、取り出した値を返す処理
-    $result = $this->card->drawCard($this->cards);
+    $result = $this->cardRule->drawCard($this->cards);
     $this->cards = array_slice($this->cards, 1);
     return $result;
   }
 
   public function getRank(int|string $drawnCard): int
   {
-    return $this->card->getRank($drawnCard);
+    return $this->cardRule->getRank($drawnCard);
+  }
+
+  public function calculateTotalCardNumber(array $hands): array
+  {
+    list($cardHands, $totalCardNumber) = $this->cardRule->calculateTotalCardNumber($hands);
+    return [$cardHands, $totalCardNumber];
   }
 
   public function getBustNumber(): int
   {
-    return $this->card->getBustNumber();
+    return $this->cardRule->getBustNumber();
   }
 
   public function judgeTheWinner(Player $player, Dealer $dealer): string
   {
-    return $this->card->judgeTheWinner($player, $dealer);
+    return $this->cardRule->judgeTheWinner($player, $dealer);
   }
 
   //　テストコードでのみ使用

--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -5,20 +5,23 @@ namespace BlackJack;
 require_once(__DIR__ . '../../../lib/black_jack/Player.php');
 require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
 require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRule.php');
 
 use BlackJack\Player;
 use BlackJack\Dealer;
 use BlackJack\Deck;
-use Exception;
+use BlackJack\CardRule;
+use \Exception;
 
 class Game
 {
   const FIRST_DRAW_CARD_NUMBER = 2;
 
-  public function start()
+  public function start(): string
   {
     $this->startMessage();
-    list($player, $dealer, $deck) = $this->setupInstances();
+    $cardRule = $this->getRule();
+    list($player, $dealer, $deck) = $this->setupInstances($cardRule);
     $deck->shuffleCards();
     // 各ユーザーがカードを2枚引く処理
     for ($i = 0; $i < self::FIRST_DRAW_CARD_NUMBER; $i++) {
@@ -37,16 +40,54 @@ class Game
   }
 
   // 処理で使用するPlayer、Dealer，Deckクラスをそれぞれインスタンス化する処理
-  private function setupInstances()
+  private function setupInstances(CardRule $cardRule): array
   {
     $player = new Player;
     $dealer = new Dealer;
-    $deck = new Deck();
+    $deck = new Deck($cardRule);
     return [$player, $dealer, $deck];
   }
 
-  private function startMessage()
+  private function startMessage(): void
   {
     echo 'ブラックジャックを開始します。' . PHP_EOL;
+  }
+
+  public function getRule(): CardRule
+  {
+    $isValid = false;
+    while (!$isValid) {
+      echo 'ルールA,ルールBどちらを使用しますか?' . PHP_EOL;
+      echo 'ルールA:カードのAの数字は1点とします。' . PHP_EOL;
+      echo 'ルールB:カードのAの数字は1点もしくは11点とし、カードの合計値が21以内で最大となる方で数えるようにします。' . PHP_EOL;
+      echo 'AもしくはBにて入力してください。' . PHP_EOL;
+      $input = trim(fgets(STDIN));
+      try {
+        if ($this->validation($input)) {
+          $isValid = true;
+          if (strtolower($input) === 'a') {
+            echo 'ルールAが選択されました' . PHP_EOL;
+            return new CardRuleA();
+          } elseif (strtolower($input) === 'b') {
+            echo 'ルールBが選択されました' . PHP_EOL;
+            return new CardRuleB();
+          }
+        } elseif (!$this->validation($input)) {
+          throw new Exception('入力はAもしくはBを入力してください。' . PHP_EOL);
+        }
+      } catch (Exception $e) {
+        echo 'Error:' . $e->getMessage();
+      }
+    }
+  }
+
+  private function validation(string $input): bool
+  {
+    $inputData = strtolower($input);
+    if ($inputData === 'a' || $inputData === 'b') {
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/src/lib/black_jack/Player.php
+++ b/src/lib/black_jack/Player.php
@@ -19,16 +19,21 @@ class Player extends User
   public function drawCard(Deck $deck): array
   {
     $drawnCard = $deck->drawCard();
-    $this->totalCardsNumber += $deck->getRank($drawnCard['number']);
     $this->hands[] = $drawnCard;
+    $this->calculateTotalCardNumber($this->hands, $deck);
     return $this->hands;
+  }
+
+  protected function calculateTotalCardNumber(array $hands, Deck $deck): void
+  {
+    list($this->hands, $this->totalCardsNumber) = $deck->calculateTotalCardNumber($hands);
   }
 
   // カードを追加するかしないかを選択する処理
   public function selectCardAddOrNot(Deck $deck): void
   {
-    $drawMore = true;
-    while ($drawMore) {
+    while (true) {
+      // カードの合計を計算する処理を実装
       echo $this->getName() . 'の現在の得点は' . $this->getTotalCardsNumber() . 'です。カードを引きますか？(Y/N)' . PHP_EOL;
       try {
         $inputValue = trim(fgets(STDIN));
@@ -36,10 +41,10 @@ class Player extends User
           $this->drawCard($deck);
           $this->lastGetCardMessage();
           if ($this->getTotalCardsNumber() >= $deck->getBustNumber()) {
-            $drawMore = false;
+            break;
           }
         } elseif (!$this->inputValidation($inputValue)) {
-          $drawMore = false;
+          break;
         }
       } catch (Exception $e) {
         echo $e->getMessage();
@@ -49,7 +54,7 @@ class Player extends User
 
   // 入力内容に応じて真偽値を返す処理
   // 入力値に例外があった場合の例外処理も実装
-  private function inputValidation(string $inputValue): bool
+  protected function inputValidation(string $inputValue): bool
   {
     $inputData = strtolower($inputValue);
     if ($inputData === 'y' || $inputData === 'yes') {
@@ -96,8 +101,8 @@ class Player extends User
     $this->totalCardsNumber = $number;
   }
   //　テストコードのみに使用するメソッド
-  public function setHand(string $suit, int $number): void
+  public function setHand(string $suit, int $number, int $cardRank): void
   {
-    $this->hands[] =  ['suit' => $suit, 'number'  => $number];
+    $this->hands[] =  ['suit' => $suit, 'number'  => $number, 'cardRank' => $cardRank];
   }
 }

--- a/src/lib/black_jack/User.php
+++ b/src/lib/black_jack/User.php
@@ -7,13 +7,15 @@ abstract class User
   protected array $hands = [];
   protected int $totalCardsNumber = 0;
   protected string $name = '';
-  abstract function drawCard(Deck $deck): array;
-  abstract function selectCardAddOrNot(Deck $deck): void;
-  abstract function getTotalCardsNumber(): int;
-  abstract function getName(): string;
-  abstract function firstGetCardMessage(): void;
-  abstract function lastGetCardMessage(): void;
-  abstract function displayTotalCardsNumber(): int;
-  abstract function setTotalCardsNumber(int $number): void;
-  abstract function setHand(string $suit, int $number): void;
+
+  abstract public function drawCard(Deck $deck): array;
+  abstract protected function calculateTotalCardNumber(array $hands, Deck $deck): void;
+  abstract public function selectCardAddOrNot(Deck $deck): void;
+  abstract public function getTotalCardsNumber(): int;
+  abstract public function getName(): string;
+  abstract public function firstGetCardMessage(): void;
+  abstract public function lastGetCardMessage(): void;
+  abstract public function displayTotalCardsNumber(): int;
+  abstract public function setTotalCardsNumber(int $number): void;
+  abstract public function setHand(string $suit, int $number, int $cardRank): void;
 }

--- a/src/tests/black_jack/CardRuleATest.php
+++ b/src/tests/black_jack/CardRuleATest.php
@@ -2,38 +2,73 @@
 
 namespace BlackJack\Tests;
 
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleA.php');
+require_once(__DIR__ . '../../../lib/black_jack/Player.php');
+require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
+require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
+
 use PHPUnit\Framework\TestCase;
-use BlackJack\Card;
+use BlackJack\CardRuleA;
 use BlackJack\Player;
 use BlackJack\Dealer;
 use BlackJack\Deck;
 
 
-require_once(__DIR__ . '../../../lib/black_jack/Card.php');
-require_once(__DIR__ . '../../../lib/black_jack/Player.php');
-require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
-require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
 
-class CardTest extends TestCase
+class CardRuleATest extends TestCase
 {
   public function testDrawCard()
   {
-    $card = new Card();
-    $output = [['ハート', 'A']];
-    $this->assertSame(['ハート', 'A'], $card->drawCard($output));
+    $card = new CardRuleA();
+    $output = [['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1]];
+    $this->assertSame(['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1], $card->drawCard($output));
   }
+
   public function testGetRank()
   {
-    $card = new Card();
+    $card = new CardRuleA();
     $this->assertSame(1, $card->getRank('A'));
     $this->assertSame(5, $card->getRank(5));
     $this->assertSame(10, $card->getRank('J'));
     $this->assertSame(10, $card->getRank('Q'));
     $this->assertSame(10, $card->getRank('K'));
   }
+
+  public function testCalculateTotalCardNumber()
+  {
+    $cardRule = new CardRuleA();
+    $deck = new Deck($cardRule);
+    $hands =
+      [
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1]
+      ];
+    $expectOutputArray =
+      [
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1]
+      ];
+    $this->assertSame([$expectOutputArray, 12], $deck->calculateTotalCardNumber($hands));
+    $hands =
+      [
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'クラブ', 'number' => 'J', 'cardRank' => 10],
+        ['suit' => 'スペード', 'number' => '2', 'cardRank' => 2]
+      ];
+    $expectOutputArray =
+      [
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'クラブ', 'number' => 'J', 'cardRank' => 10],
+        ['suit' => 'スペード', 'number' => '2', 'cardRank' => 2]
+      ];
+    $this->assertSame([$expectOutputArray, 22], $deck->calculateTotalCardNumber($hands));
+  }
+
   public function testGetBustNumber()
   {
-    $card = new Card();
+    $card = new CardRuleA();
     $this->assertSame(22, $card->getBustNumber());
   }
 
@@ -41,7 +76,8 @@ class CardTest extends TestCase
   {
     $player = new Player();
     $dealer = new dealer();
-    $deck = new Deck();
+    $cardRule = new CardRuleA();
+    $deck = new Deck($cardRule);
     //　勝敗結果が'引き分けです。'となる場合
     $player->setTotalCardsNumber(21);
     $dealer->setTotalCardsNumber(21);

--- a/src/tests/black_jack/CardRuleBTest.php
+++ b/src/tests/black_jack/CardRuleBTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace BlackJack\Tests;
+
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleB.php');
+require_once(__DIR__ . '../../../lib/black_jack/Player.php');
+require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
+require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
+
+use PHPUnit\Framework\TestCase;
+use BlackJack\CardRuleB;
+use BlackJack\Player;
+use BlackJack\Dealer;
+use BlackJack\Deck;
+
+
+
+class CardRuleBTest extends TestCase
+{
+  public function testDrawCard()
+  {
+    $card = new CardRuleB();
+    $output = [['suit' => 'ハート', 'number' => 'A', 'cardRank' => 11]];
+    $this->assertSame(['suit' => 'ハート', 'number' => 'A', 'cardRank' => 11], $card->drawCard($output));
+  }
+
+  public function testGetRank()
+  {
+    $card = new CardRuleB();
+    $this->assertSame(11, $card->getRank('A'));
+    $this->assertSame(5, $card->getRank(5));
+    $this->assertSame(10, $card->getRank('J'));
+    $this->assertSame(10, $card->getRank('Q'));
+    $this->assertSame(10, $card->getRank('K'));
+  }
+
+  public function testCalculateTotalCardNumber()
+  {
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
+    $hands =
+      [
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1]
+      ];
+    $expectOutputArray =
+      [
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1]
+      ];
+    $this->assertSame([$expectOutputArray, 12], $deck->calculateTotalCardNumber($hands));
+    $hands =
+      [
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'クラブ', 'number' => '2', 'cardRank' => 2],
+        ['suit' => 'スペード', 'number' => 'A', 'cardRank' => 1]
+      ];
+    $expectOutputArray =
+      [
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'クラブ', 'number' => '2', 'cardRank' => 2],
+        ['suit' => 'スペード', 'number' => 'A', 'cardRank' => 1]
+      ];
+    $this->assertSame([$expectOutputArray, 13], $deck->calculateTotalCardNumber($hands));
+    $hands =
+      [
+        ['suit' => 'ハート', 'number' => 5, 'cardRank' => 5],
+        ['suit' => 'クラブ', 'number' => 5, 'cardRank' => 5],
+        ['suit' => 'スペード', 'number' => 'K', 'cardRank' => 10],
+        ['suit' => 'スペード', 'number' => 'A', 'cardRank' => 1]
+      ];
+    $expectOutputArray =
+      [
+        ['suit' => 'ハート', 'number' => 5, 'cardRank' => 5],
+        ['suit' => 'クラブ', 'number' => 5, 'cardRank' => 5],
+        ['suit' => 'スペード', 'number' => 'K', 'cardRank' => 10],
+        ['suit' => 'スペード', 'number' => 'A', 'cardRank' => 1]
+      ];
+    $this->assertSame([$expectOutputArray, 21], $deck->calculateTotalCardNumber($hands));
+    $hands =
+      [
+        ['suit' => 'ハート', 'number' => 5, 'cardRank' => 5],
+        ['suit' => 'クラブ', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'スペード', 'number' => 'K', 'cardRank' => 10],
+        ['suit' => 'スペード', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'スペード', 'number' => 5, 'cardRank' => 5],
+      ];
+    $expectOutputArray =
+      [
+        ['suit' => 'ハート', 'number' => 5, 'cardRank' => 5],
+        ['suit' => 'クラブ', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'スペード', 'number' => 'K', 'cardRank' => 10],
+        ['suit' => 'スペード', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'スペード', 'number' => 5, 'cardRank' => 5],
+      ];
+    $this->assertSame([$expectOutputArray, 22], $deck->calculateTotalCardNumber($hands));
+  }
+
+  public function testGetBustNumber()
+  {
+    $card = new CardRuleB();
+    $this->assertSame(22, $card->getBustNumber());
+  }
+
+  public function testJudgeTheWinner()
+  {
+    $player = new Player();
+    $dealer = new dealer();
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
+    //　勝敗結果が'引き分けです。'となる場合
+    $player->setTotalCardsNumber(21);
+    $dealer->setTotalCardsNumber(21);
+    $this->assertSame('引き分けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $player->setTotalCardsNumber(22);
+    $dealer->setTotalCardsNumber(27);
+    $this->assertSame('引き分けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    //　勝敗結果が'あなたの勝ちです!'となる場合
+    $player->setTotalCardsNumber(21);
+    $dealer->setTotalCardsNumber(18);
+    $this->assertSame('あなたの勝ちです!' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $player->setTotalCardsNumber(21);
+    $dealer->setTotalCardsNumber(23);
+    $this->assertSame('あなたの勝ちです!' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    //　勝敗結果が'あなたの負けです。'となる場合
+    $player->setTotalCardsNumber(22);
+    $dealer->setTotalCardsNumber(21);
+    $this->assertSame('あなたの負けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $player->setTotalCardsNumber(16);
+    $dealer->setTotalCardsNumber(21);
+    $this->assertSame('あなたの負けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+  }
+}

--- a/src/tests/black_jack/DealerTest.php
+++ b/src/tests/black_jack/DealerTest.php
@@ -2,32 +2,35 @@
 
 namespace BlackJack\Tests;
 
+require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleB.php');
+require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
+
 use PHPUnit\Framework\TestCase;
 use BlackJack\Deck;
-use BlackJack\Card;
+use BlackJack\CardRuleB;
 use BlackJack\Dealer;
 
-require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
-require_once(__DIR__ . '../../../lib/black_jack/Card.php');
-require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
 
 class DealerTest extends TestCase
 {
   public function testDrawCard()
   {
-    $deck = new Deck();
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
     $dealer = new Dealer();
-    $this->assertSame([['suit' => 'ハート', 'number' => 'A']], $dealer->drawCard($deck));
+    $this->assertSame([['suit' => 'ハート', 'number' => 'A', 'cardRank' => 11]], $dealer->drawCard($deck));
   }
 
   public function testGetTotalCardsNumber()
   {
-    $deck = new Deck();
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
     $dealer = new Dealer();
     $dealer->drawCard($deck);
-    $this->assertSame(1, $dealer->getTotalCardsNumber());
+    $this->assertSame(11, $dealer->getTotalCardsNumber());
     $dealer->drawCard($deck);
-    $this->assertSame(3, $dealer->getTotalCardsNumber());
+    $this->assertSame(13, $dealer->getTotalCardsNumber());
   }
   public function testGetName()
   {
@@ -38,7 +41,7 @@ class DealerTest extends TestCase
   public function testFirstGetCardMessage()
   {
     $dealer = new Dealer();
-    $dealer->setHand('ハート', 9);
+    $dealer->setHand('ハート', 9, 9);
     ob_start();
     $dealer->firstGetCardMessage();
     $output = ob_get_clean();
@@ -48,11 +51,22 @@ class DealerTest extends TestCase
   public function testLastGetCardMessage()
   {
     $dealer = new Dealer();
-    $dealer->setHand('ハート', 9);
-    $dealer->setHand('クラブ', 10);
+    $dealer->setHand('ハート', 9, 9);
+    $dealer->setHand('クラブ', 10, 10);
     ob_start();
     $dealer->lastGetCardMessage();
     $output = ob_get_clean();
     $this->assertSame('ディーラーの引いたカードはクラブの10です。' . PHP_EOL, $output);
+  }
+
+  public function testDisplayTotalCardsNumber()
+  {
+    $dealer = new Dealer();
+    $dealer->setTotalCardsNumber(19);
+    ob_start();
+    $result = $dealer->displayTotalCardsNumber();
+    $output = ob_get_clean();
+    $this->assertSame('ディーラーの得点は19です。' . PHP_EOL, $output);
+    $this->assertSame(19, $result);
   }
 }

--- a/src/tests/black_jack/DeckTest.php
+++ b/src/tests/black_jack/DeckTest.php
@@ -2,51 +2,78 @@
 
 namespace BlackJack\Tests;
 
+require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleB.php');
+
 use PHPUnit\Framework\TestCase;
 use BlackJack\Deck;
-use BlackJack\Card;
+use BlackJack\CardRuleB;
 use ReflectionMethod;
 
-require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
-require_once(__DIR__ . '../../../lib/black_jack/Card.php');
 
 class DeckTest extends TestCase
 {
   public function testShuffleCards()
   {
-    $deck  = new Deck();
+    $cardRule = new CardRuleB();
+    $deck  = new Deck($cardRule);
     $deck->shuffleCards();
-    $this->assertNotSame(['suit' => 'ハート', 'number' => 'A'], $deck->getCards());
+    $this->assertNotSame(['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1], $deck->getCards());
   }
 
   public function testShuffleArray()
   {
+    $cardRule = new CardRuleB();
     $method = new ReflectionMethod(Deck::class, 'shuffleArray');
     $method->setAccessible(true);
-    $output = $method->invoke(new Deck);
-    $this->assertNotSame(['suit' => 'ハート', 'number' => 'A'], $output[0]);
+    $output = $method->invoke(new Deck($cardRule));
+    $this->assertNotSame(['suit' => 'ハート', 'number' => 'A', 'cardRank' => 11], $output[0]);
   }
 
   public function testDrawCard()
   {
-    $deck = new Deck();
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
     $result = $deck->drawCard();
-    $this->assertSame(['suit' => 'ハート', 'number' => 'A'], $result);
+    $this->assertSame(['suit' => 'ハート', 'number' => 'A', 'cardRank' => 11], $result);
   }
 
   public function testGetRank()
   {
-    $deck = new Deck();
-    $this->assertSame(1, $deck->getRank('A'));
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
+    $this->assertSame(11, $deck->getRank('A'));
     $this->assertSame(5, $deck->getRank(5));
     $this->assertSame(10, $deck->getRank('J'));
     $this->assertSame(10, $deck->getRank('Q'));
     $this->assertSame(10, $deck->getRank('K'));
   }
 
+  public function testCalculateTotalCardNumber()
+  {
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
+    // $handsに任意の値をセットし、テストを実行
+    $hands =
+      [
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 11],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 11]
+      ];
+    $expectOutputArray =
+      [
+        ['suit' => 'ハート', 'number' => 10, 'cardRank' => 10],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1],
+        ['suit' => 'ハート', 'number' => 'A', 'cardRank' => 1]
+      ];
+
+    $this->assertSame([$expectOutputArray, 12], $deck->calculateTotalCardNumber($hands));
+  }
+
   public function testGetBustNumber()
   {
-    $deck = new Deck();
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
     $this->assertSame(22, $deck->getBustNumber());
   }
 }

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -2,19 +2,23 @@
 
 namespace BlackJack\Tests;
 
+require_once(__DIR__ . '../../../lib/black_jack/Game.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleA.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleB.php');
+
 use PHPUnit\Framework\TestCase;
 use BlackJack\Game;
+use BlackJack\CardRuleA;
+use BlackJack\CardRuleB;
 
-require_once(__DIR__ . '../../../lib/black_jack/Game.php');
 
 class GameTest extends TestCase
 {
   public function testStart()
   {
     $game = new Game();
-    $result = trim($game->start());
-    var_dump($result);
-    $expectingOutputString = ['あなたの負けです。', 'あなたの勝ちです!', '引き分けです。'];
+    $result = $game->start();
+    $expectingOutputString = ['あなたの負けです。' . PHP_EOL, 'あなたの勝ちです!' . PHP_EOL, '引き分けです。' . PHP_EOL];
     $this->assertContains($result, $expectingOutputString, 'いずれもふくまれておりません。');
   }
 }

--- a/src/tests/black_jack/PlayerTest.php
+++ b/src/tests/black_jack/PlayerTest.php
@@ -2,33 +2,37 @@
 
 namespace BlackJack\Tests;
 
+require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleB.php');
+require_once(__DIR__ . '../../../lib/black_jack/Player.php');
+
 use PHPUnit\Framework\TestCase;
 use BlackJack\Deck;
-use BlackJack\Card;
+use BlackJack\CardRuleB;
 use BlackJack\Player;
 
-require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
-require_once(__DIR__ . '../../../lib/black_jack/Card.php');
-require_once(__DIR__ . '../../../lib/black_jack/Player.php');
 
 class PlayerTest extends TestCase
 {
   public function testDrawCard()
   {
-    $deck = new Deck();
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
     $player = new Player();
-    $this->assertSame([['suit' => 'ハート', 'number' => 'A']], $player->drawCard($deck));
+    $this->assertSame([['suit' => 'ハート', 'number' => 'A', 'cardRank' => 11]], $player->drawCard($deck));
   }
 
   public function testGetTotalCardsNumber()
   {
-    $deck = new Deck();
+    $cardRule = new CardRuleB();
+    $deck = new Deck($cardRule);
     $player = new Player();
     $player->drawCard($deck);
-    $this->assertSame(1, $player->getTotalCardsNumber());
+    $this->assertSame(11, $player->getTotalCardsNumber());
     $player->drawCard($deck);
-    $this->assertSame(3, $player->getTotalCardsNumber());
+    $this->assertSame(13, $player->getTotalCardsNumber());
   }
+
   public function testGetName()
   {
     $player = new Player();
@@ -37,12 +41,12 @@ class PlayerTest extends TestCase
   public function testFirstGetCardMessage()
   {
     $player = new Player();
-    $player->setHand('ハート', 9);
+    $player->setHand('ハート', 9, 9);
     ob_start();
     $player->firstGetCardMessage();
     $output = ob_get_clean();
     $this->assertSame('あなたの引いたカードはハートの9です。' . PHP_EOL, $output);
-    $player->setHand('クラブ', 10);
+    $player->setHand('クラブ', 10, 10);
     ob_start();
     $player->firstGetCardMessage();
     $output = ob_get_clean();
@@ -51,11 +55,22 @@ class PlayerTest extends TestCase
   public function testLastGetCardMessage()
   {
     $player = new Player();
-    $player->setHand('ハート', 9);
-    $player->setHand('クラブ', 10);
+    $player->setHand('ハート', 9, 9);
+    $player->setHand('クラブ', 10, 10);
     ob_start();
     $player->lastGetCardMessage();
     $output = ob_get_clean();
     $this->assertSame('あなたの引いたカードはクラブの10です。' . PHP_EOL, $output);
+  }
+
+  public function testDisplayTotalCardsNumber()
+  {
+    $player = new Player();
+    $player->setTotalCardsNumber(19);
+    ob_start();
+    $result = $player->displayTotalCardsNumber();
+    $output = ob_get_clean();
+    $this->assertSame('あなたの得点は19です。' . PHP_EOL, $output);
+    $this->assertSame(19, $result);
   }
 }


### PR DESCRIPTION
新たなルールとして、手札の合計値が21を最大値となるよう、Aが1もしくは11にその都度変化するよう修正を加えました。
それに伴い、Card.phpを抽象クラスのCardRule.phpという抽象クラスに修正し、それをCardRuleA、CardRuleBという具象クラスにて継承させるようにしました。
CardRuleAでは、Aを1として扱い、CardRuleBでは今回の仕様変更のようにAを1もしくは11として扱っております。

■CardRuleを選択する処理を追加
Gameクラスのstart()にてgetRule()を追加しました。このメソッドでは、標準入力によりAもしくはBを入力し、入力値の条件判定処理によりCardRuleAもしくはCardRuleBインスタンスを生成し、Deckクラス生成時の引数として渡しております。
※Deckクラスの引数として渡すことにより、手札の合計値を計算するcalculateTotalCardNumber()等のメソッドの詳細をDeckクラスは知る必要がなく、今後CardRuleが新たに追加されたとしても修正箇所の影響を抑えることができます。

■手札の合計値を計算する処理をCardRuleクラスに実装
Player、DealerクラスのdrawCard()にて手札の合計値であるtotalCardNumberプロパティに値を加えておりましたが、この処理をCardRuleクラスに移動させました。CardRuleクラスに移動させたため、今回の仕様変更のようなCardの計算方法が変更となる仕様変更が生じた際においても、Player、Dealerクラスは手札の合計値を計算するcalculateTotalCardNumber()の詳細を知る必要がないため、修正箇所の影響を抑えることができます。

■$handsに'cardRank'キーを追加
Player、Dealerクラスの持つ手札、$hands連想配列のプロパティに新たに'cardRank'キーを追加しました。
'cardRank'を追加したことで、今回の仕様変更であるAの値がその時の手札の合計値によって変化するような修正があった際も修正箇所を抑え、柔軟に対応することが可能となっております。

■CardRuleBクラスのcalculateTotalCardNumber()について
$handsとして手札、$sumとして手札の合計値を返す処理です。
この処理では、手札の'cardRank'の値をarray_column()とarray_sum()を組み合わせることで、合計し、$sumに格納し、$sumが22を超えていてかつ'cardRank'に11が含まれている場合（つまり、手札にAがある状態）、Aの'cardRank'を1に変更し、$sumから10引く処理を行っております。この際、foreachにて$handsを$handとしてループさせておりますが、&$handとリファレンスを用いることで、$handsの'cardRank'に$handへの変更を反映させております。

■その他
・Playerクラスがカードを追加で引くか選択するselectCardAddOrNot()では、カードの合計値が22を超えた時点で処理が終了し、$deckのjudgeTheWinner()にて負けが確定します。
※Playerが22を超えた時点でDealerはカードの合計値が17以上になるまでカードを引くselectCardAddOrNot()の処理を行いません。

・CardRule具象クラスの持つ judgeTheWinner()ではPlayer、Dealerクラスの手札の合計値を比較し、引き分け、勝ち、負けの３ついずれかを返しております。