### PR TITLE
CPUを最大2名追加できるように仕様変更しました。

### DIFF
--- a/src/lib/black_jack/AutoPlayer.php
+++ b/src/lib/black_jack/AutoPlayer.php
@@ -9,11 +9,12 @@ use BlackJack\User;
 use BlackJack\Deck;
 use \Exception;
 
-class Player extends User
+class AutoPlayer extends User
 {
-  public function __construct()
+  const KEEP_DRAWING_NUMBER = 17;
+  public function __construct(string $name)
   {
-    $this->name = 'あなた';
+    $this->name = $name;
   }
 
   public function drawCard(Deck $deck): array
@@ -32,23 +33,10 @@ class Player extends User
   // カードを追加するかしないかを選択する処理
   public function selectHitOrStand(Deck $deck): void
   {
-    while (true) {
-      // カードの合計を計算する処理を実装
-      echo $this->getName() . 'の現在の得点は' . $this->getTotalCardsNumber() . 'です。カードを引きますか？(Y/N)' . PHP_EOL;
-      try {
-        $inputValue = trim(fgets(STDIN));
-        if ($this->inputValidation($inputValue)) {
-          $this->drawCard($deck);
-          $this->lastGetCardMessage();
-          if ($this->getTotalCardsNumber() >= $deck->getBustNumber()) {
-            break;
-          }
-        } elseif (!$this->inputValidation($inputValue)) {
-          break;
-        }
-      } catch (Exception $e) {
-        echo $e->getMessage();
-      }
+    while ($this->totalCardsNumber < self::KEEP_DRAWING_NUMBER) {
+      echo $this->getName() . 'の現在の得点は' . $this->getTotalCardsNumber() . 'です。' . PHP_EOL;
+      $this->drawCard($deck);
+      $this->lastGetCardMessage();
     }
   }
 

--- a/src/lib/black_jack/CardRule.php
+++ b/src/lib/black_jack/CardRule.php
@@ -10,7 +10,7 @@ abstract class CardRule
   abstract public function getRank(int|string $drawnCard): int;
   abstract public function calculateTotalCardNumber(array $hands): array;
   abstract public function getBustNumber(): int;
-  abstract public function judgeTheWinner(Player $player, Dealer $dealer): string;
+  abstract public function judgeTheWinner(array $players, Dealer $dealer): array;
   abstract protected function isPush(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool;
   abstract protected function isWin(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool;
   abstract protected function isLoss(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool;

--- a/src/lib/black_jack/CardRuleA.php
+++ b/src/lib/black_jack/CardRuleA.php
@@ -47,16 +47,21 @@ class CardRuleA extends CardRule
     return self::BUST_NUMBER;
   }
 
-  public function judgeTheWinner(Player $player, Dealer $dealer): string
+  public function judgeTheWinner(array $players, Dealer $dealer): array
   {
-    $playerTotalCardsNumber = $player->displayTotalCardsNumber();
+    $result = [];
     $dealerTotalCardsNumber = $dealer->displayTotalCardsNumber();
-    if ($this->isPush($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
-      return '引き分けです。' . PHP_EOL;
-    } elseif ($this->isWin($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
-      return  $player->getName() . 'の勝ちです!' . PHP_EOL;
-    } elseif ($this->isLoss($playerTotalCardsNumber, $dealerTotalCardsNumber))
-      return $player->getName() . 'の負けです。' . PHP_EOL;
+    foreach ($players as $player) {
+      $playerTotalCardsNumber = $player->displayTotalCardsNumber();
+      if ($this->isPush($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
+        $result[] =  $player->getName() . 'は引き分けです。' . PHP_EOL;
+      } elseif ($this->isWin($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
+        $result[] = $player->getName() . 'は勝ちです!' . PHP_EOL;
+      } elseif ($this->isLoss($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
+        $result[] = $player->getName() . 'は負けです。' . PHP_EOL;
+      }
+    }
+    return $result;
   }
 
   protected function isPush(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool

--- a/src/lib/black_jack/CardRuleB.php
+++ b/src/lib/black_jack/CardRuleB.php
@@ -53,16 +53,21 @@ class CardRuleB extends CardRule
     return self::BUST_NUMBER;
   }
 
-  public function judgeTheWinner(Player $player, Dealer $dealer): string
+  public function judgeTheWinner(array $players, Dealer $dealer): array
   {
-    $playerTotalCardsNumber = $player->displayTotalCardsNumber();
+    $result = [];
     $dealerTotalCardsNumber = $dealer->displayTotalCardsNumber();
-    if ($this->isPush($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
-      return '引き分けです。' . PHP_EOL;
-    } elseif ($this->isWin($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
-      return  $player->getName() . 'の勝ちです!' . PHP_EOL;
-    } elseif ($this->isLoss($playerTotalCardsNumber, $dealerTotalCardsNumber))
-      return $player->getName() . 'の負けです。' . PHP_EOL;
+    foreach ($players as $player) {
+      $playerTotalCardsNumber = $player->displayTotalCardsNumber();
+      if ($this->isPush($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
+        $result[] =  $player->getName() . 'は引き分けです。' . PHP_EOL;
+      } elseif ($this->isWin($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
+        $result[] = $player->getName() . 'の勝ちです!' . PHP_EOL;
+      } elseif ($this->isLoss($playerTotalCardsNumber, $dealerTotalCardsNumber)) {
+        $result[] = $player->getName() . 'の負けです。' . PHP_EOL;
+      }
+    }
+    return $result;
   }
 
   protected function isPush(int $playerTotalCardsNumber, int $dealerTotalCardsNumber): bool

--- a/src/lib/black_jack/Dealer.php
+++ b/src/lib/black_jack/Dealer.php
@@ -30,7 +30,7 @@ class Dealer extends User
     list($this->hands, $this->totalCardsNumber) = $deck->calculateTotalCardNumber($hands);
   }
 
-  public function selectCardAddOrNot(Deck $deck): void
+  public function selectHitOrStand(Deck $deck): void
   {
     while ($this->totalCardsNumber < self::KEEP_DRAWING_NUMBER) {
       echo $this->getName() . 'の現在の得点は' . $this->getTotalCardsNumber() . 'です。' . PHP_EOL;

--- a/src/lib/black_jack/Deck.php
+++ b/src/lib/black_jack/Deck.php
@@ -56,7 +56,7 @@ class Deck
     return $this->cardRule->getBustNumber();
   }
 
-  public function judgeTheWinner(Player $player, Dealer $dealer): string
+  public function judgeTheWinner(array $player, Dealer $dealer): array
   {
     return $this->cardRule->judgeTheWinner($player, $dealer);
   }

--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -3,49 +3,64 @@
 namespace BlackJack;
 
 require_once(__DIR__ . '../../../lib/black_jack/Player.php');
+require_once(__DIR__ . '../../../lib/black_jack/AutoPlayer.php');
 require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
 require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
-require_once(__DIR__ . '../../../lib/black_jack/CardRule.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleA.php');
+require_once(__DIR__ . '../../../lib/black_jack/CardRuleB.php');
 
 use BlackJack\Player;
+use BlackJack\AutoPlayer;
 use BlackJack\Dealer;
 use BlackJack\Deck;
-use BlackJack\CardRule;
+use BlackJack\CardRuleA;
+use BlackJack\CardRuleB;
 use \Exception;
 
 class Game
 {
   const FIRST_DRAW_CARD_NUMBER = 2;
 
-  public function start(): string
+  public function start(): array
   {
     $this->startMessage();
+    $numberOfAutoPlayer = $this->getNumberOfAutoPlayer();
     $cardRule = $this->getRule();
-    list($player, $dealer, $deck) = $this->setupInstances($cardRule);
+    list($players, $dealer, $deck) = $this->setupInstances($cardRule, $numberOfAutoPlayer);
     $deck->shuffleCards();
     // 各ユーザーがカードを2枚引く処理
     for ($i = 0; $i < self::FIRST_DRAW_CARD_NUMBER; $i++) {
-      $player->drawCard($deck);
+      array_map(fn($player) => $player->drawCard($deck), $players);
       $dealer->drawCard($deck);
     }
-    $player->firstGetCardMessage();
+    array_map(fn($player) => $player->firstGetCardMessage(), $players);
     $dealer->firstGetCardMessage();
-    $player->selectCardAddOrNot($deck);
+    array_map(fn($player) => $player->selectHitOrStand($deck), $players);
     $dealer->displaySecondCardMessage();
-    if ($player->getTotalCardsNumber() < $deck->getBustNumber()) {
-      $dealer->selectCardAddOrNot($deck);
+    if ($players[0]->getTotalCardsNumber() < $deck->getBustNumber()) {
+      $dealer->selectHitOrStand($deck);
     }
-    $result = $deck->judgeTheWinner($player, $dealer);
-    return $result;
+    $results = $deck->judgeTheWinner($players, $dealer);
+    foreach ($results as $result) {
+      echo $result;
+    }
+    return $results;
   }
 
-  // 処理で使用するPlayer、Dealer，Deckクラスをそれぞれインスタンス化する処理
-  private function setupInstances(CardRule $cardRule): array
+  // 処理で使用するPlayers、Dealer，Deckクラスをそれぞれインスタンス化する処理
+  private function setupInstances(CardRule $cardRule, int $numberOfAutoPlayer): array
   {
-    $player = new Player;
     $dealer = new Dealer;
     $deck = new Deck($cardRule);
-    return [$player, $dealer, $deck];
+    $players = [];
+    $players[] = new Player();
+    if ($numberOfAutoPlayer > 0) {
+      for ($i = 1; $i < ($numberOfAutoPlayer + 1); $i++) {
+        $autoPlayerName = 'cpu' . $i;
+        $players[] = new AutoPlayer($autoPlayerName);
+      }
+    }
+    return [$players, $dealer, $deck];
   }
 
   private function startMessage(): void
@@ -53,26 +68,53 @@ class Game
     echo 'ブラックジャックを開始します。' . PHP_EOL;
   }
 
+  private function getNumberOfAutoPlayer(): int
+  {
+    while (true) {
+      echo 'コンピューターは何人参加させますか？' . PHP_EOL;
+      echo '0,1,2のいずれかを入力してください' . PHP_EOL;
+      $numberOfAutoPlayer = trim(fgets(STDIN));
+      $isNotError = $this->validateAutoPlayer($numberOfAutoPlayer);
+      try {
+        if ($isNotError) {
+          return $numberOfAutoPlayer;
+        } elseif (!$isNotError) {
+          throw new Exception('入力値に0,1,2以外が入力されてます。' . PHP_EOL);
+        }
+      } catch (Exception $e) {
+        echo 'Error:' . $e->getMessage();
+      }
+    }
+  }
+
+  private function validateAutoPlayer(string $numberOfAutoPlayer): bool
+  {
+    if (in_array($numberOfAutoPlayer, ['0', '1', '2'], true)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   public function getRule(): CardRule
   {
-    $isValid = false;
-    while (!$isValid) {
+    while (true) {
       echo 'ルールA,ルールBどちらを使用しますか?' . PHP_EOL;
       echo 'ルールA:カードのAの数字は1点とします。' . PHP_EOL;
       echo 'ルールB:カードのAの数字は1点もしくは11点とし、カードの合計値が21以内で最大となる方で数えるようにします。' . PHP_EOL;
       echo 'AもしくはBにて入力してください。' . PHP_EOL;
-      $input = trim(fgets(STDIN));
+      $ruleType = trim(fgets(STDIN));
+      $isNotError = $this->ValidateRule($ruleType);
       try {
-        if ($this->validation($input)) {
-          $isValid = true;
-          if (strtolower($input) === 'a') {
+        if ($isNotError) {
+          if (strtolower($ruleType) === 'a') {
             echo 'ルールAが選択されました' . PHP_EOL;
             return new CardRuleA();
-          } elseif (strtolower($input) === 'b') {
+          } elseif (strtolower($ruleType) === 'b') {
             echo 'ルールBが選択されました' . PHP_EOL;
             return new CardRuleB();
           }
-        } elseif (!$this->validation($input)) {
+        } elseif (!$isNotError) {
           throw new Exception('入力はAもしくはBを入力してください。' . PHP_EOL);
         }
       } catch (Exception $e) {
@@ -81,10 +123,10 @@ class Game
     }
   }
 
-  private function validation(string $input): bool
+  private function ValidateRule(string $ruleType): bool
   {
-    $inputData = strtolower($input);
-    if ($inputData === 'a' || $inputData === 'b') {
+    $inputRuleType = strtolower($ruleType);
+    if ($inputRuleType === 'a' || $inputRuleType === 'b') {
       return true;
     } else {
       return false;

--- a/src/lib/black_jack/User.php
+++ b/src/lib/black_jack/User.php
@@ -10,7 +10,7 @@ abstract class User
 
   abstract public function drawCard(Deck $deck): array;
   abstract protected function calculateTotalCardNumber(array $hands, Deck $deck): void;
-  abstract public function selectCardAddOrNot(Deck $deck): void;
+  abstract public function selectHitOrStand(Deck $deck): void;
   abstract public function getTotalCardsNumber(): int;
   abstract public function getName(): string;
   abstract public function firstGetCardMessage(): void;

--- a/src/tests/black_jack/CardRuleATest.php
+++ b/src/tests/black_jack/CardRuleATest.php
@@ -4,12 +4,14 @@ namespace BlackJack\Tests;
 
 require_once(__DIR__ . '../../../lib/black_jack/CardRuleA.php');
 require_once(__DIR__ . '../../../lib/black_jack/Player.php');
+require_once(__DIR__ . '../../../lib/black_jack/AutoPlayer.php');
 require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
 require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
 
 use PHPUnit\Framework\TestCase;
 use BlackJack\CardRuleA;
 use BlackJack\Player;
+use BlackJack\AutoPlayer;
 use BlackJack\Dealer;
 use BlackJack\Deck;
 
@@ -74,30 +76,36 @@ class CardRuleATest extends TestCase
 
   public function testJudgeTheWinner()
   {
-    $player = new Player();
+    $players = [];
+    $players[] = new Player();
+    $players[] = new AutoPlayer('cpu1');
+    $players[] = new AutoPlayer('cpu2');
     $dealer = new dealer();
     $cardRule = new CardRuleA();
     $deck = new Deck($cardRule);
     //　勝敗結果が'引き分けです。'となる場合
-    $player->setTotalCardsNumber(21);
+    array_map(fn($player) => $player->setTotalCardsNumber(21), $players);
     $dealer->setTotalCardsNumber(21);
-    $this->assertSame('引き分けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
-    $player->setTotalCardsNumber(22);
+    $expectedOutputString = ['あなたは引き分けです。' . PHP_EOL, 'cpu1は引き分けです。' . PHP_EOL, 'cpu2は引き分けです。' . PHP_EOL];
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
+    array_map(fn($player) => $player->setTotalCardsNumber(22), $players);
     $dealer->setTotalCardsNumber(27);
-    $this->assertSame('引き分けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
     //　勝敗結果が'あなたの勝ちです!'となる場合
-    $player->setTotalCardsNumber(21);
+    array_map(fn($player) => $player->setTotalCardsNumber(21), $players);
+    $expectedOutputString = ['あなたは勝ちです!' . PHP_EOL, 'cpu1は勝ちです!' . PHP_EOL, 'cpu2は勝ちです!' . PHP_EOL];
     $dealer->setTotalCardsNumber(18);
-    $this->assertSame('あなたの勝ちです!' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
-    $player->setTotalCardsNumber(21);
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
+    array_map(fn($player) => $player->setTotalCardsNumber(21), $players);
     $dealer->setTotalCardsNumber(23);
-    $this->assertSame('あなたの勝ちです!' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
     //　勝敗結果が'あなたの負けです。'となる場合
-    $player->setTotalCardsNumber(22);
+    array_map(fn($player) => $player->setTotalCardsNumber(22), $players);
     $dealer->setTotalCardsNumber(21);
-    $this->assertSame('あなたの負けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
-    $player->setTotalCardsNumber(16);
+    $expectedOutputString = ['あなたは負けです。' . PHP_EOL, 'cpu1は負けです。' . PHP_EOL, 'cpu2は負けです。' . PHP_EOL];
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
+    array_map(fn($player) => $player->setTotalCardsNumber(16), $players);
     $dealer->setTotalCardsNumber(21);
-    $this->assertSame('あなたの負けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
   }
 }

--- a/src/tests/black_jack/CardRuleBTest.php
+++ b/src/tests/black_jack/CardRuleBTest.php
@@ -4,12 +4,14 @@ namespace BlackJack\Tests;
 
 require_once(__DIR__ . '../../../lib/black_jack/CardRuleB.php');
 require_once(__DIR__ . '../../../lib/black_jack/Player.php');
+require_once(__DIR__ . '../../../lib/black_jack/AutoPlayer.php');
 require_once(__DIR__ . '../../../lib/black_jack/Dealer.php');
 require_once(__DIR__ . '../../../lib/black_jack/Deck.php');
 
 use PHPUnit\Framework\TestCase;
 use BlackJack\CardRuleB;
 use BlackJack\Player;
+use BlackJack\AutoPlayer;
 use BlackJack\Dealer;
 use BlackJack\Deck;
 
@@ -106,30 +108,36 @@ class CardRuleBTest extends TestCase
 
   public function testJudgeTheWinner()
   {
-    $player = new Player();
+    $players = [];
+    $players[] = new Player();
+    $players[] = new AutoPlayer('cpu1');
+    $players[] = new AutoPlayer('cpu2');
     $dealer = new dealer();
     $cardRule = new CardRuleB();
     $deck = new Deck($cardRule);
     //　勝敗結果が'引き分けです。'となる場合
-    $player->setTotalCardsNumber(21);
+    array_map(fn($player) => $player->setTotalCardsNumber(21), $players);
     $dealer->setTotalCardsNumber(21);
-    $this->assertSame('引き分けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
-    $player->setTotalCardsNumber(22);
+    $expectedOutputString = ['あなたは引き分けです。' . PHP_EOL, 'cpu1は引き分けです。' . PHP_EOL, 'cpu2は引き分けです。' . PHP_EOL];
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
+    array_map(fn($player) => $player->setTotalCardsNumber(22), $players);
     $dealer->setTotalCardsNumber(27);
-    $this->assertSame('引き分けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
     //　勝敗結果が'あなたの勝ちです!'となる場合
-    $player->setTotalCardsNumber(21);
+    array_map(fn($player) => $player->setTotalCardsNumber(21), $players);
+    $expectedOutputString = ['あなたの勝ちです!' . PHP_EOL, 'cpu1の勝ちです!' . PHP_EOL, 'cpu2の勝ちです!' . PHP_EOL];
     $dealer->setTotalCardsNumber(18);
-    $this->assertSame('あなたの勝ちです!' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
-    $player->setTotalCardsNumber(21);
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
+    array_map(fn($player) => $player->setTotalCardsNumber(21), $players);
     $dealer->setTotalCardsNumber(23);
-    $this->assertSame('あなたの勝ちです!' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
     //　勝敗結果が'あなたの負けです。'となる場合
-    $player->setTotalCardsNumber(22);
+    array_map(fn($player) => $player->setTotalCardsNumber(22), $players);
     $dealer->setTotalCardsNumber(21);
-    $this->assertSame('あなたの負けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
-    $player->setTotalCardsNumber(16);
+    $expectedOutputString = ['あなたの負けです。' . PHP_EOL, 'cpu1の負けです。' . PHP_EOL, 'cpu2の負けです。' . PHP_EOL];
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
+    array_map(fn($player) => $player->setTotalCardsNumber(16), $players);
     $dealer->setTotalCardsNumber(21);
-    $this->assertSame('あなたの負けです。' . PHP_EOL, $deck->judgeTheWinner($player, $dealer));
+    $this->assertSame($expectedOutputString, $deck->judgeTheWinner($players, $dealer));
   }
 }

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -5,11 +5,15 @@ namespace BlackJack\Tests;
 require_once(__DIR__ . '../../../lib/black_jack/Game.php');
 require_once(__DIR__ . '../../../lib/black_jack/CardRuleA.php');
 require_once(__DIR__ . '../../../lib/black_jack/CardRuleB.php');
+require_once(__DIR__ . '../../../lib/black_jack/Player.php');
+require_once(__DIR__ . '../../../lib/black_jack/AutoPlayer.php');
 
 use PHPUnit\Framework\TestCase;
 use BlackJack\Game;
 use BlackJack\CardRuleA;
 use BlackJack\CardRuleB;
+use BlackJack\Player;
+use BlackJack\AutoPlayer;
 
 
 class GameTest extends TestCase
@@ -17,8 +21,15 @@ class GameTest extends TestCase
   public function testStart()
   {
     $game = new Game();
-    $result = $game->start();
-    $expectingOutputString = ['あなたの負けです。' . PHP_EOL, 'あなたの勝ちです!' . PHP_EOL, '引き分けです。' . PHP_EOL];
-    $this->assertContains($result, $expectingOutputString, 'いずれもふくまれておりません。');
+    $results = $game->start();
+    $players[] = new Player();
+    $players[] = new AutoPlayer('cpu1');
+    $players[] = new AutoPlayer('cpu2');
+    foreach ($players as $player) {
+      $expectingOutputStrings[] = [$player->getName() . 'の負けです。' . PHP_EOL, $player->getName() . 'の勝ちです!' . PHP_EOL, $player->getName() . 'は引き分けです。' . PHP_EOL];
+    }
+    for ($i = 0; $i < count($results); $i++) {
+      $this->assertContains($results[$i], $expectingOutputStrings[$i], 'いずれもふくまれておりません。');
+    }
   }
 }


### PR DESCRIPTION
ブラックジャックゲームプログラムにてゲームを自動で進めるCPUを最大2名追加できるように仕様変更を行いました。
ゲーム開始時にCPUを何名追加するかを入力することでゲームに参加させるCPUの数を選択できるようにしております。

■AutoPlayerクラスの作成
Userクラスを継承したAutoPlayerクラスを作成しました。このクラスは、ブラックジャックゲームに参加させるCPUのクラスとなります。ゲームでは、GameクラスのgetNumberOfAutoPlayer()によって取得した値に応じてCPU1,CPU2のようにAutoPlayerオブジェクトが生成され、Playerオブジェクトとともにゲームに参加させております。
・__constract()に関して
オブジェクト生成時に引数として受け取った文字列をNameプロパティにセットするようにしており、CPU1,CPU2…とCPUの名前をCPUの参加数に関係なく、動的にセットできるようにしております。
・selectHitOrStand()に関して
カードを引くか引かないかを選択するこの処理では、ディーラー同様、手札の合計値が17以上になるまでカードを引き続けるようにしております。

■Gameクラス
参加人数に応じて処理を動的なものにするため、もともとPlayerオブジェクトを格納していた$playerを$playersとして変更したおります。その$playersにPlayerオブジェクトおよびAutoPlayerオブジェクトをそれぞれ格納させ、array_map()によって、$playersの全要素に対して処理を実行させるようにしております。
・参加させるCPUの数を入力するgetNumberOfAutoPlayer()に関して
このメソッドでは、標準入力として入力値を受けとり、入力値をメソッド内のvalidateAutoPlayer()にてバリデーション処理しております。validateAutoPlayer()では、入力値が0,1,2のいずれかであれば入力値を返し、それ以外の場合は例外処理としてエラーメッセージを表示し、CPUの参加人数の標準入力処理を無限ループさせております。
